### PR TITLE
Add per-measurement level filtering of metrics.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -119,9 +119,12 @@ like `MyClass`).  If you want to operable on the conventional "full"
 name (`org.example.foo.MyClass`) enable `useQualifiedName`.
 
 If you want to report only a subset of the measurements that are
-typically reported by a meter then use can use the measurement
-options on the predicate configuration. The per-measurement filters
-are only applied only if a metric has passed the top level filter.
+reported by a meter then use can use the measurement
+options on the predicate configuration. This feature is only available
+if you include as a dependency a fork of the metrics project that
+supports this feature, such as http://github.com/mspiegel/metrics.
+If the per measurement filtering is available then it is only
+applied once a metric has passed the top level filter.
 
     ganglia:
       -

--- a/src/main/java/com/addthis/metrics/reporter/config/PredicateConfig.java
+++ b/src/main/java/com/addthis/metrics/reporter/config/PredicateConfig.java
@@ -72,6 +72,13 @@ public class PredicateConfig implements MetricPredicate
             this.color = color;
             this.useQualifiedName = useQualifiedName;
         }
+
+        public String getColor() { return color; }
+        public boolean getUseQualifiedName() { return useQualifiedName; }
+        public List<MeasurementSpecification> getPatterns() { return patterns; }
+        public void setColor(String color) { this.color = color; }
+        public void setUseQualifiedName(boolean value) { this.useQualifiedName = value; }
+        public void setPatterns(List<MeasurementSpecification> patterns) { this.patterns = patterns; }
     }
 
     public static class MeasurementSpecification
@@ -82,6 +89,10 @@ public class PredicateConfig implements MetricPredicate
         private String measure;
 
         public MeasurementSpecification() {}
+        public String getMetric() { return metric; }
+        public String getMeasure() { return measure; }
+        public void setMetric(String metric) { this.metric = metric; }
+        public void setMeasure(String measure) { this.measure = measure; }
     }
 
     public static class MeasurementPattern
@@ -105,7 +116,6 @@ public class PredicateConfig implements MetricPredicate
     private List<MeasurementPattern> histogramPatterns;
     private List<MeasurementPattern> timerPatterns;
 
-    @SuppressWarnings("unused")
     public PredicateConfig() {}
 
     public PredicateConfig(String color, List<String> patterns)
@@ -120,7 +130,6 @@ public class PredicateConfig implements MetricPredicate
         setUseQualifiedName(useQualifiedName);
     }
 
-    @SuppressWarnings("unused")
     public String getColor()
     {
         return color;
@@ -131,7 +140,6 @@ public class PredicateConfig implements MetricPredicate
         this.color = color;
     }
 
-    @SuppressWarnings("unused")
     public List<String> getPatterns()
     {
         return patterns;
@@ -147,7 +155,6 @@ public class PredicateConfig implements MetricPredicate
         }
     }
 
-    @SuppressWarnings("unused")
     public boolean getUseQualifiedName()
     {
         return useQualifiedName;
@@ -158,39 +165,33 @@ public class PredicateConfig implements MetricPredicate
         this.useQualifiedName = useQualifiedName;
     }
 
-    @SuppressWarnings("unused")
     public Measurement getMeter()
     {
         return meter;
     }
 
-    @SuppressWarnings("unused")
     public Measurement getHistogram()
     {
         return histogram;
     }
 
-    @SuppressWarnings("unused")
     public Measurement getTimer()
     {
         return timer;
     }
 
-    @SuppressWarnings("unused")
     public void setMeter(Measurement meter)
     {
         this.meter = meter;
         this.meterPatterns = createMeasurementPatterns(meter);
     }
 
-    @SuppressWarnings("unused")
     public void setHistogram(Measurement histogram)
     {
         this.histogram = histogram;
         this.histogramPatterns = createMeasurementPatterns(histogram);
     }
 
-    @SuppressWarnings("unused")
     public void setTimer(Measurement timer)
     {
         this.timer = timer;
@@ -268,7 +269,7 @@ public class PredicateConfig implements MetricPredicate
     }
 
     public static boolean allowMeasurement(String name, String measurement,
-                                    Measurement type, List<MeasurementPattern> patterns)
+                                           Measurement type, List<MeasurementPattern> patterns)
     {
         if (type.color.equals("black"))
         {
@@ -302,7 +303,7 @@ public class PredicateConfig implements MetricPredicate
     }
 
     public boolean allowMeasurement(MetricName name, String measurement,
-                                           Measurement type, List<MeasurementPattern> patterns)
+                                    Measurement type, List<MeasurementPattern> patterns)
     {
         if (type.useQualifiedName)
         {
@@ -316,9 +317,11 @@ public class PredicateConfig implements MetricPredicate
 
     /**
      * This will only be invoked if using a fork of the metrics library with support
-     * for filtering on a per-measurement basis - http://github.com/mspiegel/metrics
+     * for filtering on a per-measurement basis - http://github.com/mspiegel/metrics.
+     * Otherwise this method is not invoked. The @Override annotation is omitted so
+     * that compilation is successful using either the metrics library or the fork of the
+     * metrics library.
      */
-    @SuppressWarnings("unused")
     public boolean matches(MetricName name, Metric metric, String measurement)
     {
         if ((meter != null) && (metric instanceof Meter))

--- a/src/test/java/com/addthis/metrics/reporter/config/PredicateConfigTest.java
+++ b/src/test/java/com/addthis/metrics/reporter/config/PredicateConfigTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import com.yammer.metrics.core.MetricName;
 import org.junit.Test;
 
 public class PredicateConfigTest
@@ -147,6 +149,21 @@ public class PredicateConfigTest
         assertFalse(PredicateConfig.allowMeasurement("foo", "bars", type, patternList));
         assertFalse(PredicateConfig.allowMeasurement("foos", "bar", type, patternList));
         assertTrue(PredicateConfig.allowMeasurement("foos", "bars", type, patternList));
+    }
+
+    @Test
+    public void qualifiedNameMeasurement()
+    {
+        PredicateConfig pc = new PredicateConfig("white", new ArrayList());
+        Measurement type = new Measurement("white", true);
+        MeasurementPattern pattern = new MeasurementPattern(
+            "^com.addthis.metrics.reporter.config.PredicateConfigTest.+", "min");
+        List<MeasurementPattern> patternList = new ArrayList<MeasurementPattern>();
+        patternList.add(pattern);
+        MetricName name1 = new MetricName(PredicateConfigTest.class, "name", "scope");
+        assertTrue(pc.allowMeasurement(name1, "min", type, patternList));
+        MetricName name2 = new MetricName(PredicateConfig.class, "name", "scope");
+        assertFalse(pc.allowMeasurement(name2, "min", type, patternList));
     }
 
     @Test

--- a/src/test/java/com/addthis/metrics/reporter/config/sample/ValidateTest.java
+++ b/src/test/java/com/addthis/metrics/reporter/config/sample/ValidateTest.java
@@ -37,6 +37,7 @@ public class ValidateTest
         ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/ganglia.yaml");
         ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/ganglia-gmond.yaml");
         ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/ganglia-gmond-predicate.yaml");
+        ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/ganglia-gmond-predicate-measurement.yaml");
         ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/graphite.yaml");
         ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/multi.yaml");
     }

--- a/src/test/resources/sample/ganglia-gmond-predicate-measurement.yaml
+++ b/src/test/resources/sample/ganglia-gmond-predicate-measurement.yaml
@@ -1,0 +1,16 @@
+ganglia:
+  -
+    period: 60
+    timeunit: 'SECONDS'
+    gmondConf: '/etc/ganglia/gmond.conf'
+    predicate:
+       color: "black"
+       patterns:
+       - ".*JMXONLY$"
+       histogram:
+         color: "white"
+         patterns:
+           - metric: ".*WidgetRunner$"
+             measure: "[mean|stddev]"
+           - metric: ".*SprocketRunner$"
+             measure: ".*percentile"


### PR DESCRIPTION
Here is a patch that adds measurement level filtering of metrics. Most of the heavy lifting was done in a fork of the Metrics 2.2.0 release. Here is the diff of that fork: https://github.com/mspiegel/metrics/compare/codahale:v2.2.0...v2.2.0-measurement-filter.

I've added to the README file in metrics-reporter-config an example that uses the measurement predicate:

```
ganglia:
  -
    period: 60
    timeunit: 'SECONDS'
    gmondConf: '/etc/ganglia/gmond.conf'
    predicate:
      color: "black"
      patterns:
      - ".*JMXONLY$"
      histogram:
          color: "white"
          patterns:
          - metric: ".*WidgetRunner$"
            measure: "[mean|stddev]"
          - metric: ".*SprocketRunner$"
            measure: ".*percentile"
```

This patch will compile with both the forked and unforked versions of metrics library. It overrides the method MetricPredicate#matches(MetricName name, Metric metric, String measurement) that exists only in the forked version. In metrics-reporter-config I did not add the @Override annotation to allow for compilation in either case.

Question: should I push to the maven central repository an artifact named com.yammer.metrics.metrics-core with a version number of 2.2.0-measurement-filter and then change the metrics-reporter-config pom.xml to use that version as a dependency?
