### PR TITLE
Adds support for "prefix" parameter in Ganglia reporter. 

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -143,10 +143,10 @@ metric has passed the top level filter.
               - metric: ".*SprocketRunner$"
                 measure: ".*percentile"
 
-### Graphite reporter
+### Graphite and Ganglia
 
-Graphite reporter supports the "prefix" parameter. Its value will be
-prepended to each metric name sent by GraphiteReporter. This value
+The Graphite and Ganglia reporters supports the "prefix" parameter. Its value will be
+prepended to each metric name sent by reporter. This value
 may contain one of the following variable references using "${variable.name}"
 as format.
 
@@ -156,7 +156,8 @@ as format.
 	- host.fqdn = the value returned for local host by `java.net.InetAddress#getCanonicalHostName()`
 
 Each substituted value gets sanitized by replacing all characters that
-are not allowed in the host name plus "-" with the underscore.
+are not allowed in the host name plus "-" with the underscore. The Ganglia reporter additionally
+supports the "groupPrefix" parameter. This will add a prefix to the Ganglia metric group.
 
 ## Building
 

--- a/src/main/java/com/addthis/metrics/reporter/config/GangliaReporterConfig.java
+++ b/src/main/java/com/addthis/metrics/reporter/config/GangliaReporterConfig.java
@@ -15,6 +15,7 @@
 package com.addthis.metrics.reporter.config;
 
 import com.yammer.metrics.Metrics;
+import com.yammer.metrics.reporting.MetricPrefixGangliaReporter;
 
 import java.util.List;
 
@@ -32,17 +33,6 @@ public class GangliaReporterConfig extends AbstractHostPortReporterConfig
     @NotNull
     private boolean compressPackageNames = false;
     private String gmondConf;
-
-
-    public String getGroupPrefix()
-    {
-        return groupPrefix;
-    }
-
-    public void setGroupPrefix(String groupPrefix)
-    {
-        this.groupPrefix = groupPrefix;
-    }
 
     public boolean getCompressPackageNames()
     {
@@ -104,9 +94,9 @@ public class GangliaReporterConfig extends AbstractHostPortReporterConfig
             log.info("Enabling GangliaReporter to {}:{}", new Object[] {hostPort.getHost(), hostPort.getPort()});
             try
             {
-                com.yammer.metrics.reporting.GangliaReporter.enable(Metrics.defaultRegistry(), getPeriod(), getRealTimeunit(),
-                                                                    hostPort.getHost(), hostPort.getPort(), groupPrefix,
-                                                                    getMetricPredicate(), compressPackageNames);
+                MetricPrefixGangliaReporter.enable(Metrics.defaultRegistry(), getPeriod(), getRealTimeunit(),
+                        hostPort.getHost(), hostPort.getPort(), resolvePrefix(groupPrefix),
+                        getResolvedPrefix(), getMetricPredicate(), compressPackageNames);
             }
             catch (Exception e)
             {

--- a/src/main/java/com/addthis/metrics/reporter/config/GraphiteReporterConfig.java
+++ b/src/main/java/com/addthis/metrics/reporter/config/GraphiteReporterConfig.java
@@ -15,15 +15,8 @@
 package com.addthis.metrics.reporter.config;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import javax.validation.constraints.NotNull;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.StrSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,14 +26,6 @@ public class GraphiteReporterConfig extends AbstractHostPortReporterConfig
 {
     private static final Logger log = LoggerFactory.getLogger(GraphiteReporterConfig.class);
 
-    public static final String MACRO_HOST_NAME = "host.name";
-    public static final String MACRO_HOST_ADDRESS = "host.address";
-    public static final String MACRO_HOST_FQDN = "host.fqdn";
-    public static final String MACRO_HOST_NAME_SHORT = "host.name.short";
-
-    private InetAddress localhost;
-    private String resolvedPrefix;
-
     /**
      * Test constructor
      * 
@@ -48,82 +33,11 @@ public class GraphiteReporterConfig extends AbstractHostPortReporterConfig
      *            localhost
      */
     GraphiteReporterConfig(InetAddress localhost) {
-        this.localhost = localhost;
+        super(localhost);
     }
 
     public GraphiteReporterConfig() {
-        try {
-            this.localhost = InetAddress.getLocalHost();
-        } catch (UnknownHostException e) {
-            // not expected to happen with properly configured system
-            log.error("Unable to get localhost", e);
-        }
-    }
-    
-    @NotNull
-    private String prefix = "";
-
-    public String getPrefix()
-    {
-        return prefix;
-    }
-
-    /**
-     * <p>
-     * Sets the prefix to be prepended to all metric names. The prefix may
-     * contain the variable references in the following format: ${macro_name}.
-     * <p>
-     * The following macros are supported:
-     * <dl>
-     * <dt>{@link #MACRO_HOST_ADDRESS}</dt>
-     * <dd>The value returned for local host by
-     * {@link InetAddress#getHostAddress()}</dd>
-     * <dt>{@link #MACRO_HOST_NAME}</dt>
-     * <dd>The value returned for local host by
-     * {@link InetAddress#getHostName()}</dd>
-     * <dt>{@link #MACRO_HOST_NAME_SHORT}</dt>
-     * <dd>The value returned for local host by
-     * {@link InetAddress#getHostName()} up to first dot</dd>
-     * <dt>{@link #MACRO_HOST_FQDN}</dt>
-     * <dd>The value returned for local host by
-     * {@link InetAddress#getCanonicalHostName()}</dd>
-     * </dl>
-     * 
-     * <p>
-     * All substituted values are made metric-safe
-     * 
-     * @param prefix
-     *            prefix value
-     */
-    public void setPrefix(String prefix) {
-        this.prefix = prefix;
-        this.resolvedPrefix = resolvePrefix(prefix);
-    }
-
-    private String resolvePrefix(String prefixTemplate) {
-        Map<String, String> valueMap = new HashMap<String, String>();
-        if (localhost != null) {
-            String hostname = localhost.getHostName();
-            valueMap.put(MACRO_HOST_NAME, sanitizeName(hostname));
-            if (!StringUtils.isEmpty(hostname)) {
-                valueMap.put(MACRO_HOST_NAME_SHORT,
-                        sanitizeName(StringUtils.split(hostname, '.')[0]));
-            }
-            valueMap.put(MACRO_HOST_ADDRESS,
-                    sanitizeName(localhost.getHostAddress()));
-            valueMap.put(MACRO_HOST_FQDN,
-                    sanitizeName(localhost.getCanonicalHostName()));
-        }
-
-        return StrSubstitutor.replace(prefixTemplate, valueMap);
-    }
-	
-    private String sanitizeName(String name) {
-        return name.replaceAll("[^a-zA-Z0-9_-]", "_");
-    }
-
-    String getResolvedPrefix() {
-        return this.resolvedPrefix;
+        super();
     }
 
     @Override
@@ -153,7 +67,7 @@ public class GraphiteReporterConfig extends AbstractHostPortReporterConfig
             {
                 log.info("Enabling GraphiteReporter to {}:{}", new Object[] {hostPort.getHost(), hostPort.getPort()});
                 com.yammer.metrics.reporting.GraphiteReporter.enable(Metrics.defaultRegistry(), getPeriod(), getRealTimeunit(),
-                                                                     hostPort.getHost(), hostPort.getPort(), resolvedPrefix, getMetricPredicate());
+                                                                     hostPort.getHost(), hostPort.getPort(), getResolvedPrefix(), getMetricPredicate());
 
             }
             catch (Exception e)

--- a/src/main/java/com/yammer/metrics/reporting/MetricPrefixGangliaReporter.java
+++ b/src/main/java/com/yammer/metrics/reporting/MetricPrefixGangliaReporter.java
@@ -1,0 +1,532 @@
+/**
+ * Adapted from com.yammer.metrics.reporting.GangliaReporter from version 2.2.0 of the
+ * com.yammer.metrics library:
+ *
+ * http://github.com/dropwizard/metrics/blob/v2.2.0/metrics-ganglia/src/main/java/com/yammer/metrics/reporting/GangliaReporter.java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yammer.metrics.reporting;
+
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.*;
+import com.yammer.metrics.stats.Snapshot;
+import com.yammer.metrics.core.MetricPredicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A simple reporter which sends out application metrics to a <a href="http://ganglia.sourceforge.net/">Ganglia</a>
+ * server periodically.
+ * <p/>
+ * NOTE: this reporter only works with Ganglia 3.1 and greater.  The message protocol for earlier
+ * versions of Ganglia is different.
+ * <p/>
+ * This code heavily borrows from GangliaWriter in <a href="http://code.google.com/p/jmxtrans/source/browse/trunk/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java">JMXTrans</a>
+ * which is based on <a href="http://search-hadoop.com/c/Hadoop:/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/ganglia/GangliaContext31.java">GangliaContext31</a>
+ * from Hadoop.
+ */
+public class MetricPrefixGangliaReporter extends AbstractPollingReporter implements MetricProcessor<String> {
+    private static final Logger LOG = LoggerFactory.getLogger(MetricPrefixGangliaReporter.class);
+    private static final int GANGLIA_TMAX = 60;
+    private static final int GANGLIA_DMAX = 0;
+    private static final String GANGLIA_INT_TYPE = "int32";
+    private static final String GANGLIA_DOUBLE_TYPE = "double";
+    private static final String GANGLIA_STRING_TYPE = "string";
+    private final MetricPredicate predicate;
+    private final VirtualMachineMetrics vm;
+    private final Locale locale = Locale.US;
+    private String hostLabel;
+    private String groupPrefix = "";
+    private String metricPrefix = "";
+    private boolean compressPackageNames;
+    private final GangliaMessageBuilder gangliaMessageBuilder;
+    public boolean printVMMetrics = true;
+
+    /**
+     * Enables the ganglia reporter to send data for the default metrics registry to ganglia server
+     * with the specified period.
+     *
+     * @param period      the period between successive outputs
+     * @param unit        the time unit of {@code period}
+     * @param gangliaHost the gangliaHost name of ganglia server (carbon-cache agent)
+     * @param port        the port number on which the ganglia server is listening
+     */
+    public static void enable(long period, TimeUnit unit, String gangliaHost, int port) {
+        enable(Metrics.defaultRegistry(), period, unit, gangliaHost, port, "");
+    }
+
+    /**
+     * Enables the ganglia reporter to send data for the default metrics registry to ganglia server
+     * with the specified period.
+     *
+     * @param period      the period between successive outputs
+     * @param unit        the time unit of {@code period}
+     * @param gangliaHost the gangliaHost name of ganglia server (carbon-cache agent)
+     * @param port        the port number on which the ganglia server is listening
+     * @param groupPrefix prefix to the ganglia group name (such as myapp_counter)
+     */
+    public static void enable(long period, TimeUnit unit, String gangliaHost, int port, String groupPrefix) {
+        enable(Metrics.defaultRegistry(), period, unit, gangliaHost, port, groupPrefix);
+    }
+
+    /**
+     * Enables the ganglia reporter to send data for the default metrics registry to ganglia server
+     * with the specified period.
+     *
+     * @param period               the period between successive outputs
+     * @param unit                 the time unit of {@code period}
+     * @param gangliaHost          the gangliaHost name of ganglia server (carbon-cache agent)
+     * @param port                 the port number on which the ganglia server is listening
+     * @param compressPackageNames if true reporter will compress package names e.g.
+     *                             com.foo.MetricName becomes c.f.MetricName
+     */
+    public static void enable(long period, TimeUnit unit, String gangliaHost, int port, boolean compressPackageNames) {
+        enable(Metrics.defaultRegistry(),
+                period,
+                unit,
+                gangliaHost,
+                port,
+                "",
+                null,
+                MetricPredicate.ALL,
+                compressPackageNames);
+    }
+
+
+    /**
+     * Enables the ganglia reporter to send data for the given metrics registry to ganglia server
+     * with the specified period.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param period          the period between successive outputs
+     * @param unit            the time unit of {@code period}
+     * @param gangliaHost     the gangliaHost name of ganglia server (carbon-cache agent)
+     * @param port            the port number on which the ganglia server is listening
+     * @param groupPrefix     prefix to the ganglia group name (such as myapp_counter)
+     */
+    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit, String gangliaHost, int port, String groupPrefix) {
+        enable(metricsRegistry, period, unit, gangliaHost, port, groupPrefix, MetricPredicate.ALL);
+    }
+
+    /**
+     * Enables the ganglia reporter to send data to ganglia server with the specified period.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param period          the period between successive outputs
+     * @param unit            the time unit of {@code period}
+     * @param gangliaHost     the gangliaHost name of ganglia server (carbon-cache agent)
+     * @param port            the port number on which the ganglia server is listening
+     * @param groupPrefix     prefix to the ganglia group name (such as myapp_counter)
+     * @param predicate       filters metrics to be reported
+     */
+    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit, String gangliaHost, int port, String groupPrefix, MetricPredicate predicate) {
+        enable(metricsRegistry, period, unit, gangliaHost, port, groupPrefix, null, predicate, false);
+    }
+
+    /**
+     * Enables the ganglia reporter to send data to ganglia server with the specified period.
+     *
+     * @param metricsRegistry      the metrics registry
+     * @param period               the period between successive outputs
+     * @param unit                 the time unit of {@code period}
+     * @param gangliaHost          the gangliaHost name of ganglia server (carbon-cache agent)
+     * @param port                 the port number on which the ganglia server is listening
+     * @param groupPrefix          prefix to the ganglia group name (such as myapp_counter)
+     * @param predicate            filters metrics to be reported
+     * @param compressPackageNames if true reporter will compress package names e.g.
+     *                             com.foo.MetricName becomes c.f.MetricName
+     */
+    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit, String gangliaHost,
+            int port, String groupPrefix, String metricPrefix, MetricPredicate predicate, boolean compressPackageNames) {
+        try {
+            final MetricPrefixGangliaReporter reporter = new MetricPrefixGangliaReporter(metricsRegistry,
+                    gangliaHost,
+                    port,
+                    groupPrefix,
+                    metricPrefix,
+                    predicate,
+                    compressPackageNames);
+            reporter.start(period, unit);
+        } catch (Exception e) {
+            LOG.error("Error creating/starting ganglia reporter:", e);
+        }
+    }
+
+    /**
+     * Creates a new {@link MetricPrefixGangliaReporter}.
+     *
+     * @param gangliaHost is ganglia server
+     * @param port        is port on which ganglia server is running
+     * @throws java.io.IOException if there is an error connecting to the ganglia server
+     */
+    public MetricPrefixGangliaReporter(String gangliaHost, int port) throws IOException {
+        this(Metrics.defaultRegistry(), gangliaHost, port, "");
+    }
+
+    /**
+     * Creates a new {@link MetricPrefixGangliaReporter}.
+     *
+     * @param gangliaHost          is ganglia server
+     * @param port                 is port on which ganglia server is running
+     * @param compressPackageNames whether or not Metrics' package names will be shortened
+     * @throws java.io.IOException if there is an error connecting to the ganglia server
+     */
+    public MetricPrefixGangliaReporter(String gangliaHost, int port, boolean compressPackageNames) throws IOException {
+        this(Metrics.defaultRegistry(),
+                gangliaHost,
+                port,
+                "",
+                null,
+                MetricPredicate.ALL,
+                compressPackageNames);
+    }
+
+    /**
+     * Creates a new {@link MetricPrefixGangliaReporter}.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param gangliaHost     is ganglia server
+     * @param port            is port on which ganglia server is running
+     * @param groupPrefix     prefix to the ganglia group name (such as myapp_counter)
+     * @throws java.io.IOException if there is an error connecting to the ganglia server
+     */
+    public MetricPrefixGangliaReporter(MetricsRegistry metricsRegistry, String gangliaHost, int port, String groupPrefix) throws IOException {
+        this(metricsRegistry, gangliaHost, port, groupPrefix, MetricPredicate.ALL);
+    }
+
+    /**
+     * Creates a new {@link MetricPrefixGangliaReporter}.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param gangliaHost     is ganglia server
+     * @param port            is port on which ganglia server is running
+     * @param groupPrefix     prefix to the ganglia group name (such as myapp_counter)
+     * @param predicate       filters metrics to be reported
+     * @throws java.io.IOException if there is an error connecting to the ganglia server
+     */
+    public MetricPrefixGangliaReporter(MetricsRegistry metricsRegistry, String gangliaHost, int port, String groupPrefix, MetricPredicate predicate) throws IOException {
+        this(metricsRegistry, gangliaHost, port, groupPrefix, null, predicate, false);
+    }
+
+    /**
+     * Creates a new {@link MetricPrefixGangliaReporter}.
+     *
+     * @param metricsRegistry      the metrics registry
+     * @param gangliaHost          is ganglia server
+     * @param port                 is port on which ganglia server is running
+     * @param metricPrefix         prefix added to each metric name
+     * @param groupPrefix          prefix to the ganglia group name (such as myapp_counter)
+     * @param predicate            filters metrics to be reported
+     * @param compressPackageNames if true reporter will compress package names e.g.
+     *                             com.foo.MetricName becomes c.f.MetricName
+     * @throws java.io.IOException if there is an error connecting to the ganglia server
+     */
+    public MetricPrefixGangliaReporter(MetricsRegistry metricsRegistry, String gangliaHost, int port, String groupPrefix,
+            String metricPrefix, MetricPredicate predicate, boolean compressPackageNames) throws IOException {
+        this(metricsRegistry,
+                groupPrefix,
+                metricPrefix,
+                predicate,
+                compressPackageNames,
+                new GangliaMessageBuilder(gangliaHost, port), VirtualMachineMetrics.getInstance());
+    }
+
+    /**
+     * Creates a new {@link MetricPrefixGangliaReporter}.
+     *
+     * @param metricsRegistry          the metrics registry
+     * @param groupPrefix              prefix to the ganglia group name (such as myapp_counter)
+     * @param metricPrefix             prefix added to each metric name
+     * @param predicate                filters metrics to be reported
+     * @param compressPackageNames     if true reporter will compress package names e.g.
+     *                                 com.foo.MetricName becomes c.f.MetricName
+     * @param gangliaMessageBuilder    a {@link GangliaMessageBuilder} instance
+     * @param vm                       a {@link VirtualMachineMetrics} isntance
+     * @throws java.io.IOException if there is an error connecting to the ganglia server
+     */
+    public MetricPrefixGangliaReporter(MetricsRegistry metricsRegistry, String groupPrefix,
+            String metricPrefix,
+            MetricPredicate predicate, boolean compressPackageNames,
+            GangliaMessageBuilder gangliaMessageBuilder, VirtualMachineMetrics vm) throws IOException {
+        super(metricsRegistry, "ganglia-reporter");
+        this.gangliaMessageBuilder = gangliaMessageBuilder;
+        this.groupPrefix = StringUtils.isEmpty(groupPrefix) ? "" : (groupPrefix + "_");
+        this.metricPrefix = StringUtils.isEmpty(metricPrefix) ? "" : (metricPrefix + ".");
+        this.hostLabel = getHostLabel();
+        this.predicate = predicate;
+        this.compressPackageNames = compressPackageNames;
+        this.vm = vm;
+    }
+
+    @Override
+    public void run() {
+        if (this.printVMMetrics) {
+            printVmMetrics();
+        }
+        printRegularMetrics();
+    }
+
+    private void printRegularMetrics() {
+        for (Map.Entry<String, SortedMap<MetricName, Metric>> entry : getMetricsRegistry().groupedMetrics(
+                predicate).entrySet()) {
+            for (Map.Entry<MetricName, Metric> subEntry : entry.getValue().entrySet()) {
+                final Metric metric = subEntry.getValue();
+                if (metric != null) {
+                    try {
+                        metric.processWith(this, subEntry.getKey(), null);
+                    } catch (Exception ignored) {
+                        LOG.error("Error printing regular metrics:", ignored);
+                    }
+                }
+            }
+        }
+    }
+
+    private void sendToGanglia(String metricName, String metricType, String metricValue, String groupName, String units) {
+        try {
+
+            sendMetricData(metricType, metricPrefix + metricName, metricValue, groupPrefix + groupName, units);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Emitting metric " + metricName + ", type " + metricType + ", value " + metricValue + " for gangliaHost: " + this
+                        .gangliaMessageBuilder
+                        .getHostName() + ":" + this.gangliaMessageBuilder.getPort());
+            }
+        } catch (IOException e) {
+            LOG.error("Error sending to ganglia:", e);
+        }
+    }
+
+    private void sendToGanglia(String metricName, String metricType, String metricValue, String groupName) {
+        sendToGanglia(metricName, metricType, metricValue, groupName, "");
+    }
+
+    private void sendMetricData(String metricType, String metricName, String metricValue, String groupName, String units) throws IOException {
+
+        this.gangliaMessageBuilder.newMessage()
+                .addInt(128)// metric_id = metadata_msg
+                .addString(this.hostLabel)// hostname
+                .addString(metricName)// metric name
+                .addInt(0)// spoof = True
+                .addString(metricType)// metric type
+                .addString(metricName)// metric name
+                .addString(units)// units
+                .addInt(3)// slope see gmetric.c
+                .addInt(GANGLIA_TMAX)// tmax, the maximum time between metrics
+                .addInt(GANGLIA_DMAX)// dmax, the maximum data value
+                .addInt(1)
+                .addString("GROUP")// Group attribute
+                .addString(groupName)// Group value
+                .send();
+
+        this.gangliaMessageBuilder.newMessage()
+                .addInt(133)// we are sending a string value
+                .addString(this.hostLabel)// hostLabel
+                .addString(metricName)// metric name
+                .addInt(0)// spoof = True
+                .addString("%s")// format field
+                .addString(metricValue) // metric value
+                .send();
+    }
+
+    @Override
+    public void processGauge(MetricName name, Gauge<?> gauge, String x) throws IOException {
+        final Object value = gauge.value();
+        final Class<?> klass = value.getClass();
+
+        final String type;
+        if (klass == Integer.class || klass == Long.class) {
+            type = GANGLIA_INT_TYPE;
+        } else if (klass == Float.class || klass == Double.class) {
+            type = GANGLIA_DOUBLE_TYPE;
+        } else {
+            type = GANGLIA_STRING_TYPE;
+        }
+
+        sendToGanglia(sanitizeName(name),
+                type,
+                String.format(locale, "%s", gauge.value()),
+                "gauge");
+    }
+
+    @Override
+    public void processCounter(MetricName name, Counter counter, String x) throws IOException {
+        sendToGanglia(sanitizeName(name),
+                GANGLIA_INT_TYPE,
+                String.format(locale, "%d", counter.count()),
+                "counter");
+    }
+
+    @Override
+    public void processMeter(MetricName name, Metered meter, String x) throws IOException {
+        final String sanitizedName = sanitizeName(name);
+        final String rateUnits = meter.rateUnit().name();
+        final String rateUnit = rateUnits.substring(0, rateUnits.length() - 1).toLowerCase(Locale.US);
+        final String unit = meter.eventType() + '/' + rateUnit;
+        printLongField(sanitizedName + ".count", meter.count(), "metered", meter.eventType());
+        printDoubleField(sanitizedName + ".meanRate", meter.meanRate(), "metered", unit);
+        printDoubleField(sanitizedName + ".1MinuteRate", meter.oneMinuteRate(), "metered", unit);
+        printDoubleField(sanitizedName + ".5MinuteRate", meter.fiveMinuteRate(), "metered", unit);
+        printDoubleField(sanitizedName + ".15MinuteRate", meter.fifteenMinuteRate(), "metered", unit);
+    }
+
+    @Override
+    public void processHistogram(MetricName name, Histogram histogram, String x) throws IOException {
+        final String sanitizedName = sanitizeName(name);
+        final Snapshot snapshot = histogram.getSnapshot();
+        // TODO:  what units make sense for histograms?  should we add event type to the Histogram metric?
+        printDoubleField(sanitizedName + ".min", histogram.min(), "histo");
+        printDoubleField(sanitizedName + ".max", histogram.max(), "histo");
+        printDoubleField(sanitizedName + ".mean", histogram.mean(), "histo");
+        printDoubleField(sanitizedName + ".stddev", histogram.stdDev(), "histo");
+        printDoubleField(sanitizedName + ".median", snapshot.getMedian(), "histo");
+        printDoubleField(sanitizedName + ".75percentile", snapshot.get75thPercentile(), "histo");
+        printDoubleField(sanitizedName + ".95percentile", snapshot.get95thPercentile(), "histo");
+        printDoubleField(sanitizedName + ".98percentile", snapshot.get98thPercentile(), "histo");
+        printDoubleField(sanitizedName + ".99percentile", snapshot.get99thPercentile(), "histo");
+        printDoubleField(sanitizedName + ".999percentile", snapshot.get999thPercentile(), "histo");
+    }
+
+    @Override
+    public void processTimer(MetricName name, Timer timer, String x) throws IOException {
+        processMeter(name, timer, x);
+        final String sanitizedName = sanitizeName(name);
+        final Snapshot snapshot = timer.getSnapshot();
+        final String durationUnit = timer.durationUnit().name();
+        printDoubleField(sanitizedName + ".min", timer.min(), "timer", durationUnit);
+        printDoubleField(sanitizedName + ".max", timer.max(), "timer", durationUnit);
+        printDoubleField(sanitizedName + ".mean", timer.mean(), "timer", durationUnit);
+        printDoubleField(sanitizedName + ".stddev", timer.stdDev(), "timer", durationUnit);
+        printDoubleField(sanitizedName + ".median", snapshot.getMedian(), "timer", durationUnit);
+        printDoubleField(sanitizedName + ".75percentile", snapshot.get75thPercentile(), "timer", durationUnit);
+        printDoubleField(sanitizedName + ".95percentile", snapshot.get95thPercentile(), "timer", durationUnit);
+        printDoubleField(sanitizedName + ".98percentile", snapshot.get98thPercentile(), "timer", durationUnit);
+        printDoubleField(sanitizedName + ".99percentile", snapshot.get99thPercentile(), "timer", durationUnit);
+        printDoubleField(sanitizedName + ".999percentile", snapshot.get999thPercentile(), "timer", durationUnit);
+    }
+
+    private void printDoubleField(String name, double value, String groupName, String units) {
+        sendToGanglia(name,
+                GANGLIA_DOUBLE_TYPE,
+                String.format(locale, "%2.2f", value),
+                groupName,
+                units);
+    }
+
+    private void printDoubleField(String name, double value, String groupName) {
+        printDoubleField(name, value, groupName, "");
+    }
+
+    private void printLongField(String name, long value, String groupName) {
+        printLongField(name, value, groupName, "");
+    }
+
+    private void printLongField(String name, long value, String groupName, String units) {
+        // TODO:  ganglia does not support int64, what should we do here?
+        sendToGanglia(name, GANGLIA_INT_TYPE, String.format(locale, "%d", value), groupName, units);
+    }
+
+    private void printVmMetrics() {
+        printDoubleField("jvm.memory.heap_usage", vm.heapUsage(), "jvm");
+        printDoubleField("jvm.memory.non_heap_usage", vm.nonHeapUsage(), "jvm");
+        for (Map.Entry<String, Double> pool : vm.memoryPoolUsage().entrySet()) {
+            printDoubleField("jvm.memory.memory_pool_usages." + pool.getKey(),
+                    pool.getValue(),
+                    "jvm");
+        }
+
+        printDoubleField("jvm.daemon_thread_count", vm.daemonThreadCount(), "jvm");
+        printDoubleField("jvm.thread_count", vm.threadCount(), "jvm");
+        printDoubleField("jvm.uptime", vm.uptime(), "jvm");
+        printDoubleField("jvm.fd_usage", vm.fileDescriptorUsage(), "jvm");
+
+        for (Map.Entry<Thread.State, Double> entry : vm.threadStatePercentages().entrySet()) {
+            printDoubleField("jvm.thread-states." + entry.getKey().toString().toLowerCase(),
+                    entry.getValue(),
+                    "jvm");
+        }
+
+        for (Map.Entry<String, VirtualMachineMetrics.GarbageCollectorStats> entry : vm.garbageCollectors().entrySet()) {
+            printLongField("jvm.gc." + entry.getKey() + ".time",
+                    entry.getValue().getTime(TimeUnit.MILLISECONDS),
+                    "jvm");
+            printLongField("jvm.gc." + entry.getKey() + ".runs", entry.getValue().getRuns(), "jvm");
+        }
+    }
+
+    String getHostLabel() {
+        try {
+            final InetAddress addr = InetAddress.getLocalHost();
+            return addr.getHostAddress() + ":" + addr.getHostName();
+        } catch (UnknownHostException e) {
+            LOG.error("Unable to get local gangliaHost name: ", e);
+            return "unknown";
+        }
+    }
+
+    protected String sanitizeName(MetricName name) {
+        if (name == null) {
+            return "";
+        }
+        final String qualifiedTypeName = name.getGroup() + "." + name.getType() + "." + name.getName();
+        final String metricName = name.hasScope() ? qualifiedTypeName + '.' + name.getScope() : qualifiedTypeName;
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < metricName.length(); i++) {
+            final char p = metricName.charAt(i);
+            if (!(p >= 'A' && p <= 'Z')
+                && !(p >= 'a' && p <= 'z')
+                && !(p >= '0' && p <= '9')
+                && (p != '_')
+                && (p != '-')
+                && (p != '.')
+                && (p != '\0')) {
+                sb.append('_');
+            } else {
+                sb.append(p);
+            }
+        }
+        return compressPackageName(sb.toString());
+    }
+
+    private String compressPackageName(String name) {
+        if (compressPackageNames && name.indexOf(".") > 0) {
+            final String[] nameParts = name.split("\\.");
+            final StringBuilder sb = new StringBuilder();
+            final int numParts = nameParts.length;
+            int count = 0;
+            for (String namePart : nameParts) {
+                if (++count < numParts - 1) {
+                    sb.append(namePart.charAt(0));
+                    sb.append(".");
+                } else {
+                    sb.append(namePart);
+                    if (count == numParts - 1) {
+                        sb.append(".");
+                    }
+                }
+            }
+            name = sb.toString();
+        }
+        return name;
+    }
+}


### PR DESCRIPTION
The following changes are made:
- Pull up the implementation of the 'prefix' parameter from the `GraphiteReporterConfig`
  into the `AbstractHostPortReporterConfig` so that it can be shared across the
  graphite and ganglia reporters.
- Copy/pasted the `com.yammer.metrics.reporting.GangliaReporter` class into the
  `MetricPrefixGangliaReporter` class. In `MetricPrefixGangliaReporter` implemented support
  for optional metric prefixes. The original `GangliaReporter` does not have support
  for metric prefixes although this feature has been added in version 3.x of the
  library. The `GangliaReporter` is under the Apache License 2.0.
- In the `MetricPrefixGangliaReporter` fixed a bug where empty group prefixes would
  be appended onto the group name as "_". Now only non-empty group prefixes
  are appended.
- In `GangliaReporterConfig` applied the 'prefix' macro substitution options to
  the 'groupPrefix' parameter in case someone would like to use them.
- Updated README.mdown to reflect that 'prefix' parameter is available in both
  graphite and ganglia reporter configs.
