### PR TITLE
Allow metrics-reporter-config to compile under java 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.addthis.common.build.maven.pom</groupId>
     <artifactId>jar-pom</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.1</version>
   </parent>
 
   <groupId>com.addthis.metrics</groupId>


### PR DESCRIPTION
This allows reporter-config to be compiled under java 8. Fairly uncontroversial but I thought it would be best to create a pull request.
