### PR TITLE
Implement statsd for both metrics2/metrics3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
   <properties>
     <dep.metrics2.version>2.2.0</dep.metrics2.version>
     <dep.metrics3.version>3.1.0</dep.metrics3.version>
+    <dep.metrics-statsd.version>4.1.2</dep.metrics-statsd.version>
     <project.build.targetJdk>1.6</project.build.targetJdk>
   </properties>
 
@@ -100,9 +101,29 @@
   </dependencies>
 
   <repositories>
+    <!-- re-specify central repo to ensure it's the default -->
+    <repository>
+      <id>central-force</id>
+      <name>Maven Repository Switchboard</name>
+      <layout>default</layout>
+      <url>http://repo1.maven.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <!-- riemann reporter -->
     <repository>
       <id>clojars.org</id>
       <url>http://clojars.org/repo</url>
+    </repository>
+    <!-- statsd reporter -->
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>bintray-readytalk-maven</id>
+      <name>bintray</name>
+      <url>http://dl.bintray.com/readytalk/maven</url>
     </repository>
   </repositories>
 

--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractStatsDReporterConfig.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractStatsDReporterConfig.java
@@ -44,5 +44,4 @@ public class AbstractStatsDReporterConfig extends AbstractHostPortReporterConfig
         }
         return true;
     }
-
 }

--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractStatsDReporterConfig.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractStatsDReporterConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics.reporter.config;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AbstractStatsDReporterConfig extends AbstractHostPortReporterConfig
+{
+    private static final Logger log = LoggerFactory.getLogger(AbstractStatsDReporterConfig.class);
+
+    @Override
+    public List<HostPort> getFullHostList()
+    {
+        return getHostListAndStringList();
+    }
+
+    protected boolean setup(String className)
+    {
+        if (!isClassAvailable(className))
+        {
+            log.error("Tried to enable StatsD Reporter, but class {} was not found", className);
+            return false;
+        }
+        List<HostPort> hosts = getFullHostList();
+        if (hosts == null || hosts.isEmpty())
+        {
+            log.error("No hosts specified, cannot enable StatsD Reporter");
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/reporter-config-base/src/test/resources/sample/multi.yaml
+++ b/reporter-config-base/src/test/resources/sample/multi.yaml
@@ -21,3 +21,11 @@ graphite:
     hosts:
       - host: 'localhost'
         port: 2003
+statsd:
+  -
+    period: 2
+    timeunit: 'SECONDS'
+    prefix: 'hello'
+    hosts:
+      - host: 'localhost'
+        port: 8125

--- a/reporter-config-base/src/test/resources/sample/statsd-multi.yaml
+++ b/reporter-config-base/src/test/resources/sample/statsd-multi.yaml
@@ -1,0 +1,18 @@
+statsd:
+  -
+    period: 2
+    timeunit: 'SECONDS'
+    prefix: 'hello'
+    hosts:
+      - host: 'localhost'
+        port: 8125
+      - host: 'localhost6'
+        port: 8126
+  -
+    period: 5
+    timeunit: 'SECONDS'
+    prefix: 'hi'
+    hosts:
+      - host: '127.0.0.1'
+        port: 8127
+

--- a/reporter-config-base/src/test/resources/sample/statsd.yaml
+++ b/reporter-config-base/src/test/resources/sample/statsd.yaml
@@ -1,0 +1,8 @@
+statsd:
+  -
+    period: 2
+    timeunit: 'SECONDS'
+    prefix: 'hello'
+    hosts:
+      - host: 'localhost'
+        port: 8125

--- a/reporter-config2/pom.xml
+++ b/reporter-config2/pom.xml
@@ -49,6 +49,7 @@
             <version>${dep.metrics2.version}</version>
             <optional>true</optional>
         </dependency>
+        <!-- riemann -->
         <dependency>
             <groupId>com.aphyr</groupId>
             <artifactId>riemann-java-client</artifactId>
@@ -61,6 +62,25 @@
                 </exclusion>
                 <exclusion>
                     <groupId>com.codahale.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- statsd -->
+        <dependency>
+            <groupId>com.readytalk</groupId>
+            <artifactId>metrics-statsd-common</artifactId>
+            <version>${dep.metrics-statsd.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.readytalk</groupId>
+            <artifactId>metrics2-statsd</artifactId>
+            <version>${dep.metrics-statsd.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.yammer.metrics</groupId>
                     <artifactId>metrics-core</artifactId>
                 </exclusion>
             </exclusions>

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/ReporterConfig.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/ReporterConfig.java
@@ -43,6 +43,8 @@ public class ReporterConfig extends AbstractReporterConfig
     @Valid
     private List<RiemannReporterConfig> riemann;
     @Valid
+    private List<StatsDReporterConfig> statsd;
+    @Valid
     private List<? extends MetricsReporterConfigTwo> reporters;
 
     public List<ConsoleReporterConfig> getConsole()
@@ -93,6 +95,16 @@ public class ReporterConfig extends AbstractReporterConfig
     public void setRiemann(List<RiemannReporterConfig> riemann)
     {
         this.riemann = riemann;
+    }
+
+    public List<StatsDReporterConfig> getStatsd()
+    {
+        return statsd;
+    }
+
+    public void setStatsd(List<StatsDReporterConfig> statsd)
+    {
+        this.statsd = statsd;
     }
 
     public List<? extends MetricsReporterConfigTwo> getReporters()
@@ -213,6 +225,24 @@ public class ReporterConfig extends AbstractReporterConfig
         return !failures;
     }
 
+    public boolean enableStatsd()
+    {
+        boolean failures = false;
+        if (statsd == null)
+        {
+            log.debug("Asked to enable statsd, but it was not configured");
+            return false;
+        }
+        for (StatsDReporterConfig statsdConfig : statsd)
+        {
+            if (!statsdConfig.enable())
+            {
+                failures = true;
+            }
+        }
+        return !failures;
+    }
+
     public boolean enableAll()
     {
         boolean enabled = false;
@@ -247,6 +277,13 @@ public class ReporterConfig extends AbstractReporterConfig
         if (riemann != null)
         {
             if (enableRiemann())
+            {
+                enabled = true;
+            }
+        }
+        if (statsd != null)
+        {
+            if (enableStatsd())
             {
                 enabled = true;
             }

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/StatsDReporterConfig.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/StatsDReporterConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics.reporter.config;
+
+import com.readytalk.metrics.StatsDConstructorHack;
+import com.readytalk.metrics.StatsDReporter;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Clock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StatsDReporterConfig extends AbstractStatsDReporterConfig implements MetricsReporterConfigTwo
+{
+    private static final String REPORTER_CLASS = "com.readytalk.metrics.StatsDReporter";
+    private static final Logger log = LoggerFactory.getLogger(StatsDReporterConfig.class);
+
+    @Override
+    public boolean enable()
+    {
+        if (!setup(REPORTER_CLASS))
+        {
+            return false;
+        }
+        boolean failures = false;
+        for (HostPort hostPort : getFullHostList())
+        {
+            try
+            {
+                log.info("Enabling StatsDReporter to {}:{}",
+                    new Object[] {hostPort.getHost(), hostPort.getPort()});
+                StatsDReporter reporter = new StatsDReporter(
+                    Metrics.defaultRegistry(),
+                    getResolvedPrefix(),
+                    MetricPredicateTransformer.generatePredicate(getPredicate()),
+                    Clock.defaultClock(),
+                    new StatsDConstructorHack(hostPort.getHost(), hostPort.getPort()));
+                reporter.start(getPeriod(), getRealTimeunit());
+            }
+            catch (Exception e)
+            {
+                log.error("Failed to enable StatsDReporter to {}:{}",
+                    new Object[] {hostPort.getHost(), hostPort.getPort()}, e);
+                failures = true;
+            }
+        }
+        return !failures;
+    }
+}

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/StatsDReporterConfig.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/StatsDReporterConfig.java
@@ -65,7 +65,7 @@ public class StatsDReporterConfig extends AbstractStatsDReporterConfig implement
         return !failures;
     }
 
-    public void stopForTests() {
+    void stopForTests() {
         for (StatsDReporter reporter : reporters)
         {
             reporter.shutdown();

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/StatsDReporterConfig.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/StatsDReporterConfig.java
@@ -19,6 +19,9 @@ import com.readytalk.metrics.StatsDReporter;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Clock;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +29,8 @@ public class StatsDReporterConfig extends AbstractStatsDReporterConfig implement
 {
     private static final String REPORTER_CLASS = "com.readytalk.metrics.StatsDReporter";
     private static final Logger log = LoggerFactory.getLogger(StatsDReporterConfig.class);
+
+    private List<StatsDReporter> reporters = new ArrayList<StatsDReporter>();
 
     @Override
     public boolean enable()
@@ -48,6 +53,7 @@ public class StatsDReporterConfig extends AbstractStatsDReporterConfig implement
                     Clock.defaultClock(),
                     new StatsDConstructorHack(hostPort.getHost(), hostPort.getPort()));
                 reporter.start(getPeriod(), getRealTimeunit());
+                reporters.add(reporter);
             }
             catch (Exception e)
             {
@@ -57,5 +63,12 @@ public class StatsDReporterConfig extends AbstractStatsDReporterConfig implement
             }
         }
         return !failures;
+    }
+
+    public void stopForTests() {
+        for (StatsDReporter reporter : reporters)
+        {
+            reporter.shutdown();
+        }
     }
 }

--- a/reporter-config2/src/main/java/com/readytalk/metrics/StatsDConstructorHack.java
+++ b/reporter-config2/src/main/java/com/readytalk/metrics/StatsDConstructorHack.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.readytalk.metrics;
+
+import com.readytalk.metrics.StatsD;
+
+/**
+ * Hack to get around StatsDReporter's constructor design, which requires
+ * that a StatsD instance be passed in order to specify a MetricPredicate.
+ * This requirement conflicts with all the StatsD constructors being
+ * package-private, hence this hack to make the StatsD constructor visible.
+ *
+ * Once the library has fixed the issue, this hack can be removed. See e.g.:
+ * https://github.com/ReadyTalk/metrics-statsd/pull/27
+ */
+public class StatsDConstructorHack extends StatsD
+{
+  public StatsDConstructorHack(String host, int port)
+  {
+    super(host, port);
+  }
+}

--- a/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/StatsDReporterConfigTest.java
+++ b/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/StatsDReporterConfigTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics.reporter.config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StatsDReporterConfigTest {
+    private static final HostPort testHostPort1 = new HostPort("test_host1", 1234);
+    private static final HostPort testHostPort2 = new HostPort("test_host2", 2345);
+
+    private static final TimeUnit testRateunit = TimeUnit.DAYS;
+    private static final TimeUnit testDurationunit = TimeUnit.MICROSECONDS;
+    private static final TimeUnit testTimeunit = TimeUnit.HOURS;
+    private static final String testBadTimeunit = "BAD_UNIT";
+    private static final PredicateConfig testPredicate = new PredicateConfig("white", Arrays.asList(".*test_pattern.*"), true);
+    private static final long testPeriod = 321L;
+    private static final String testPrefix = "test_prefix";
+
+    @Test
+    public void startEmptyHosts() {
+        StatsDReporterConfig reporter = new StatsDReporterConfig();
+        assertFalse(reporter.enable());
+    }
+
+    @Test
+    public void startOneHost() {
+        StatsDReporterConfig reporter = buildConfig(
+            Arrays.asList(testHostPort1),
+            testTimeunit.toString());
+        assertTrue(reporter.enable());
+    }
+
+    @Test
+    public void startOneHostBadField() {
+        StatsDReporterConfig reporter = buildConfig(
+            Arrays.asList(testHostPort1),
+            testBadTimeunit);
+        assertFalse(reporter.enable());
+    }
+
+    @Test
+    public void startManyHosts() {
+      StatsDReporterConfig reporter = buildConfig(
+            Arrays.asList(testHostPort1, testHostPort2),
+            testTimeunit.toString());
+        assertTrue(reporter.enable());
+    }
+
+    @Test
+    public void startManyHostsBadField() {
+        StatsDReporterConfig reporter = buildConfig(
+            Arrays.asList(testHostPort1, testHostPort2),
+            testBadTimeunit);
+        assertFalse(reporter.enable());
+    }
+
+    private static StatsDReporterConfig buildConfig(List<HostPort> hosts, String timeUnit) {
+      StatsDReporterConfig reporter = new StatsDReporterConfig();
+
+      reporter.setHosts(hosts);
+
+      reporter.setRateunit(testRateunit.toString());
+      reporter.setDurationunit(testDurationunit.toString());
+      reporter.setPrefix(testPrefix);
+      reporter.setPredicate(testPredicate);
+      reporter.setPeriod(testPeriod);
+      reporter.setTimeunit(timeUnit);
+
+      return reporter;
+    }
+}

--- a/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/StatsDReporterConfigTest.java
+++ b/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/StatsDReporterConfigTest.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class StatsDReporterConfigTest {
-    private static final HostPort testHostPort1 = new HostPort("test_host1", 1234);
-    private static final HostPort testHostPort2 = new HostPort("test_host2", 2345);
+    private static final HostPort testHostPort1 = new HostPort("test-host1", 1234);
+    private static final HostPort testHostPort2 = new HostPort("test-host2", 2345);
 
     private static final TimeUnit testRateunit = TimeUnit.DAYS;
     private static final TimeUnit testDurationunit = TimeUnit.MICROSECONDS;
@@ -37,54 +37,59 @@ public class StatsDReporterConfigTest {
 
     @Test
     public void startEmptyHosts() {
-        StatsDReporterConfig reporter = new StatsDReporterConfig();
-        assertFalse(reporter.enable());
+        StatsDReporterConfig config = new StatsDReporterConfig();
+        assertFalse(config.enable());
+        config.stopForTests();
     }
 
     @Test
     public void startOneHost() {
-        StatsDReporterConfig reporter = buildConfig(
+        StatsDReporterConfig config = buildConfig(
             Arrays.asList(testHostPort1),
             testTimeunit.toString());
-        assertTrue(reporter.enable());
+        assertTrue(config.enable());
+        config.stopForTests();
     }
 
     @Test
     public void startOneHostBadField() {
-        StatsDReporterConfig reporter = buildConfig(
+        StatsDReporterConfig config = buildConfig(
             Arrays.asList(testHostPort1),
             testBadTimeunit);
-        assertFalse(reporter.enable());
+        assertFalse(config.enable());
+        config.stopForTests();
     }
 
     @Test
     public void startManyHosts() {
-      StatsDReporterConfig reporter = buildConfig(
+        StatsDReporterConfig config = buildConfig(
             Arrays.asList(testHostPort1, testHostPort2),
             testTimeunit.toString());
-        assertTrue(reporter.enable());
+        assertTrue(config.enable());
+        config.stopForTests();
     }
 
     @Test
     public void startManyHostsBadField() {
-        StatsDReporterConfig reporter = buildConfig(
+        StatsDReporterConfig config = buildConfig(
             Arrays.asList(testHostPort1, testHostPort2),
             testBadTimeunit);
-        assertFalse(reporter.enable());
+        assertFalse(config.enable());
+        config.stopForTests();
     }
 
     private static StatsDReporterConfig buildConfig(List<HostPort> hosts, String timeUnit) {
-      StatsDReporterConfig reporter = new StatsDReporterConfig();
+        StatsDReporterConfig reporter = new StatsDReporterConfig();
 
-      reporter.setHosts(hosts);
+        reporter.setHosts(hosts);
 
-      reporter.setRateunit(testRateunit.toString());
-      reporter.setDurationunit(testDurationunit.toString());
-      reporter.setPrefix(testPrefix);
-      reporter.setPredicate(testPredicate);
-      reporter.setPeriod(testPeriod);
-      reporter.setTimeunit(timeUnit);
+        reporter.setRateunit(testRateunit.toString());
+        reporter.setDurationunit(testDurationunit.toString());
+        reporter.setPrefix(testPrefix);
+        reporter.setPredicate(testPredicate);
+        reporter.setPeriod(testPeriod);
+        reporter.setTimeunit(timeUnit);
 
-      return reporter;
+        return reporter;
     }
 }

--- a/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/sample/SampleTest.java
+++ b/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/sample/SampleTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.addthis.metrics.reporter.config.CsvReporterConfig;
 import com.addthis.metrics.reporter.config.ReporterConfig;
-
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.Meter;
@@ -115,6 +114,24 @@ public class SampleTest
         ReporterConfig config = ReporterConfig.loadFromFile("src/test/resources/sample/graphite-string-dupe.yaml");
         System.out.println(yaml.dump(config));
         log.info("Graphite String Dupe");
+        runLoop(config);
+    }
+
+    @Test
+    public void sampleStatsD() throws Exception
+    {
+        ReporterConfig config = ReporterConfig.loadFromFile("src/test/resources/sample/statsd.yaml");
+        System.out.println(yaml.dump(config));
+        log.info("Sample StatsD");
+        runLoop(config);
+    }
+
+    @Test
+    public void sampleStatsDMulti() throws Exception
+    {
+        ReporterConfig config = ReporterConfig.loadFromFile("src/test/resources/sample/statsd-multi.yaml");
+        System.out.println(yaml.dump(config));
+        log.info("StatsD Multi");
         runLoop(config);
     }
 

--- a/reporter-config3/pom.xml
+++ b/reporter-config3/pom.xml
@@ -49,6 +49,25 @@
             <version>${dep.metrics3.version}</version>
             <optional>true</optional>
         </dependency>
+        <!-- statsd -->
+        <dependency>
+            <groupId>com.readytalk</groupId>
+            <artifactId>metrics-statsd-common</artifactId>
+            <version>${dep.metrics-statsd.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.readytalk</groupId>
+            <artifactId>metrics3-statsd</artifactId>
+            <version>${dep.metrics-statsd.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.codahale.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
 </project>

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/ReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/ReporterConfig.java
@@ -45,6 +45,8 @@ public class ReporterConfig extends AbstractReporterConfig
     private List<GraphiteReporterConfig> graphite;
     @Valid
     private List<RiemannReporterConfig> riemann;
+    @Valid
+    private List<StatsDReporterConfig> statsd;
 
     public List<ConsoleReporterConfig> getConsole()
     {
@@ -94,6 +96,16 @@ public class ReporterConfig extends AbstractReporterConfig
     public void setRiemann(List<RiemannReporterConfig> riemann)
     {
         this.riemann = riemann;
+    }
+
+    public List<StatsDReporterConfig> getStatsd()
+    {
+        return statsd;
+    }
+
+    public void setStatsd(List<StatsDReporterConfig> statsd)
+    {
+        this.statsd = statsd;
     }
 
     public boolean enableConsole(MetricRegistry registry)
@@ -186,6 +198,24 @@ public class ReporterConfig extends AbstractReporterConfig
         return !failures;
     }
 
+    public boolean enableStatsd(MetricRegistry registry)
+    {
+        boolean failures = false;
+        if (statsd == null)
+        {
+            log.debug("Asked to enable statsd, but it was not configured");
+            return false;
+        }
+        for (StatsDReporterConfig statsdConfig : statsd)
+        {
+            if (!statsdConfig.enable(registry))
+            {
+                failures = true;
+            }
+        }
+        return !failures;
+    }
+
     public boolean enableAll(MetricRegistry registry)
     {
         boolean enabled = false;
@@ -220,6 +250,13 @@ public class ReporterConfig extends AbstractReporterConfig
         if (riemann != null)
         {
             if (enableRiemann(registry))
+            {
+                enabled = true;
+            }
+        }
+        if (statsd != null)
+        {
+            if (enableStatsd(registry))
             {
                 enabled = true;
             }

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/StatsDReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/StatsDReporterConfig.java
@@ -73,7 +73,7 @@ public class StatsDReporterConfig extends AbstractStatsDReporterConfig implement
         }
     }
 
-    public void stopForTests() {
+    void stopForTests() {
         for (StatsDReporter reporter : reporters)
         {
             reporter.stop();

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/StatsDReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/StatsDReporterConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics3.reporter.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.addthis.metrics.reporter.config.AbstractStatsDReporterConfig;
+import com.addthis.metrics.reporter.config.HostPort;
+import com.codahale.metrics.MetricRegistry;
+import com.readytalk.metrics.StatsDReporter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StatsDReporterConfig extends AbstractStatsDReporterConfig implements MetricsReporterConfigThree
+{
+    private static final String REPORTER_CLASS = "com.readytalk.metrics.StatsDReporter";
+    private static final Logger log = LoggerFactory.getLogger(StatsDReporterConfig.class);
+
+    private List<StatsDReporter> reporters = new ArrayList<StatsDReporter>();
+
+    @Override
+    public boolean enable(MetricRegistry registry)
+    {
+        if (!setup(REPORTER_CLASS))
+        {
+            return false;
+        }
+        boolean failures = false;
+        for (HostPort hostPort : getFullHostList())
+        {
+            try
+            {
+                log.info("Enabling StatsDReporter to {}:{}",
+                    new Object[] {hostPort.getHost(), hostPort.getPort()});
+                StatsDReporter reporter = StatsDReporter.forRegistry(registry)
+                    .convertRatesTo(getRealRateunit())
+                    .convertDurationsTo(getRealDurationunit())
+                    .prefixedWith(getResolvedPrefix())
+                    .filter(MetricFilterTransformer.generateFilter(getPredicate()))
+                    .build(hostPort.getHost(), hostPort.getPort());
+                reporter.start(getPeriod(), getRealTimeunit());
+                reporters.add(reporter);
+            }
+            catch (Exception e)
+            {
+                log.error("Failed to enable StatsDReporter to {}:{}",
+                    new Object[] {hostPort.getHost(), hostPort.getPort()}, e);
+                failures = true;
+            }
+        }
+        return !failures;
+    }
+
+    @Override
+    public void report() {
+        for (StatsDReporter reporter : reporters)
+        {
+            reporter.report();
+        }
+    }
+
+    public void stopForTests() {
+        for (StatsDReporter reporter : reporters)
+        {
+            reporter.stop();
+        }
+    }
+}

--- a/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/StatsDReporterConfigTest.java
+++ b/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/StatsDReporterConfigTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics3.reporter.config;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.addthis.metrics.reporter.config.HostPort;
+import com.addthis.metrics.reporter.config.PredicateConfig;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class StatsDReporterConfigTest {
+    private static final HostPort testHostPort1 = new HostPort("test_host1", 1234);
+    private static final HostPort testHostPort2 = new HostPort("test_host2", 2345);
+
+    private static final TimeUnit testRateunit = TimeUnit.DAYS;
+    private static final TimeUnit testDurationunit = TimeUnit.MICROSECONDS;
+    private static final TimeUnit testTimeunit = TimeUnit.HOURS;
+    private static final String testBadTimeunit = "BAD_UNIT";
+    private static final PredicateConfig testPredicate = new PredicateConfig("white", Arrays.asList(".*test_pattern.*"), true);
+    private static final long testPeriod = 321L;
+    private static final String testPrefix = "test_prefix";
+
+    @Test
+    public void startEmptyHosts() {
+        MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
+        StatsDReporterConfig reporter = new StatsDReporterConfig();
+        assertFalse(reporter.enable(mockMetricRegistry));
+        verifyZeroInteractions(mockMetricRegistry);
+        reporter.stopForTests();
+    }
+
+    @Test
+    public void startOneHost() {
+        MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
+        StatsDReporterConfig reporter = buildConfig(
+            Arrays.asList(testHostPort1),
+            testTimeunit.toString());
+        assertTrue(reporter.enable(mockMetricRegistry));
+        reporter.report();
+        verifyReportEffects(mockMetricRegistry, 1);
+        reporter.stopForTests();
+    }
+
+    @Test
+    public void startOneHostBadField() {
+        MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
+        StatsDReporterConfig reporter = buildConfig(
+            Arrays.asList(testHostPort1),
+            testBadTimeunit);
+        assertFalse(reporter.enable(mockMetricRegistry));
+        reporter.report();
+        verifyZeroInteractions(mockMetricRegistry);
+        reporter.stopForTests();
+    }
+
+    @Test
+    public void startManyHosts() {
+        MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
+        StatsDReporterConfig reporter = buildConfig(
+            Arrays.asList(testHostPort1, testHostPort2),
+            testTimeunit.toString());
+        assertTrue(reporter.enable(mockMetricRegistry));
+        reporter.report();
+        verifyReportEffects(mockMetricRegistry, 2);
+        reporter.stopForTests();
+    }
+
+    @Test
+    public void startManyHostsBadField() {
+        MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
+        StatsDReporterConfig reporter = buildConfig(
+            Arrays.asList(testHostPort1, testHostPort2),
+            testBadTimeunit);
+        assertFalse(reporter.enable(mockMetricRegistry));
+        reporter.report();
+        verifyZeroInteractions(mockMetricRegistry);
+        reporter.stopForTests();
+    }
+
+    private static StatsDReporterConfig buildConfig(List<HostPort> hosts, String timeUnit) {
+        StatsDReporterConfig reporter = new StatsDReporterConfig();
+
+        reporter.setHosts(hosts);
+
+        reporter.setRateunit(testRateunit.toString());
+        reporter.setDurationunit(testDurationunit.toString());
+        reporter.setPrefix(testPrefix);
+        reporter.setPredicate(testPredicate);
+        reporter.setPeriod(testPeriod);
+        reporter.setTimeunit(timeUnit);
+
+        return reporter;
+    }
+
+    private static void verifyReportEffects(MetricRegistry mockMetricRegistry, int times) {
+        verify(mockMetricRegistry, times(times)).getGauges(Mockito.<MetricFilter>anyObject());
+        verify(mockMetricRegistry, times(times)).getCounters(Mockito.<MetricFilter>anyObject());
+        verify(mockMetricRegistry, times(times)).getHistograms(Mockito.<MetricFilter>anyObject());
+        verify(mockMetricRegistry, times(times)).getMeters(Mockito.<MetricFilter>anyObject());
+        verify(mockMetricRegistry, times(times)).getTimers(Mockito.<MetricFilter>anyObject());
+    }
+}

--- a/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/StatsDReporterConfigTest.java
+++ b/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/StatsDReporterConfigTest.java
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class StatsDReporterConfigTest {
-    private static final HostPort testHostPort1 = new HostPort("test_host1", 1234);
-    private static final HostPort testHostPort2 = new HostPort("test_host2", 2345);
+    private static final HostPort testHostPort1 = new HostPort("test-host1", 1234);
+    private static final HostPort testHostPort2 = new HostPort("test-host2", 2345);
 
     private static final TimeUnit testRateunit = TimeUnit.DAYS;
     private static final TimeUnit testDurationunit = TimeUnit.MICROSECONDS;
@@ -47,58 +47,58 @@ public class StatsDReporterConfigTest {
     @Test
     public void startEmptyHosts() {
         MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
-        StatsDReporterConfig reporter = new StatsDReporterConfig();
-        assertFalse(reporter.enable(mockMetricRegistry));
+        StatsDReporterConfig config = new StatsDReporterConfig();
+        assertFalse(config.enable(mockMetricRegistry));
         verifyZeroInteractions(mockMetricRegistry);
-        reporter.stopForTests();
+        config.stopForTests();
     }
 
     @Test
     public void startOneHost() {
         MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
-        StatsDReporterConfig reporter = buildConfig(
+        StatsDReporterConfig config = buildConfig(
             Arrays.asList(testHostPort1),
             testTimeunit.toString());
-        assertTrue(reporter.enable(mockMetricRegistry));
-        reporter.report();
+        assertTrue(config.enable(mockMetricRegistry));
+        config.report();
         verifyReportEffects(mockMetricRegistry, 1);
-        reporter.stopForTests();
+        config.stopForTests();
     }
 
     @Test
     public void startOneHostBadField() {
         MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
-        StatsDReporterConfig reporter = buildConfig(
+        StatsDReporterConfig config = buildConfig(
             Arrays.asList(testHostPort1),
             testBadTimeunit);
-        assertFalse(reporter.enable(mockMetricRegistry));
-        reporter.report();
+        assertFalse(config.enable(mockMetricRegistry));
+        config.report();
         verifyZeroInteractions(mockMetricRegistry);
-        reporter.stopForTests();
+        config.stopForTests();
     }
 
     @Test
     public void startManyHosts() {
         MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
-        StatsDReporterConfig reporter = buildConfig(
+        StatsDReporterConfig config = buildConfig(
             Arrays.asList(testHostPort1, testHostPort2),
             testTimeunit.toString());
-        assertTrue(reporter.enable(mockMetricRegistry));
-        reporter.report();
+        assertTrue(config.enable(mockMetricRegistry));
+        config.report();
         verifyReportEffects(mockMetricRegistry, 2);
-        reporter.stopForTests();
+        config.stopForTests();
     }
 
     @Test
     public void startManyHostsBadField() {
         MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
-        StatsDReporterConfig reporter = buildConfig(
+        StatsDReporterConfig config = buildConfig(
             Arrays.asList(testHostPort1, testHostPort2),
             testBadTimeunit);
-        assertFalse(reporter.enable(mockMetricRegistry));
-        reporter.report();
+        assertFalse(config.enable(mockMetricRegistry));
+        config.report();
         verifyZeroInteractions(mockMetricRegistry);
-        reporter.stopForTests();
+        config.stopForTests();
     }
 
     private static StatsDReporterConfig buildConfig(List<HostPort> hosts, String timeUnit) {

--- a/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/sample/SampleTest.java
+++ b/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/sample/SampleTest.java
@@ -20,6 +20,9 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,7 +118,27 @@ public class SampleTest
         runLoop(config);
     }
 
+    @Test
+    public void sampleStatsD() throws Exception
+    {
+        ReporterConfig config = ReporterConfig.loadFromFile("src/test/resources/sample/statsd.yaml");
+        System.out.println(yaml.dump(config));
+        log.info("Sample StatsD");
+        assertNotNull(config.getStatsd());
+        assertEquals(1, config.getStatsd().size());
+        runLoop(config);
+    }
 
+    @Test
+    public void sampleStatsDMulti() throws Exception
+    {
+        ReporterConfig config = ReporterConfig.loadFromFile("src/test/resources/sample/statsd-multi.yaml");
+        System.out.println(yaml.dump(config));
+        log.info("StatsD Multi");
+        assertNotNull(config.getStatsd());
+        assertEquals(2, config.getStatsd().size());
+        runLoop(config);
+    }
 
     @Test
     public void sampleMulti() throws Exception


### PR DESCRIPTION
Includes a full set of tests and example configs.

The metrics2 version contains a workaround for an interface problem
in the underlying reporter library. The workaround can be removed once
https://github.com/ReadyTalk/metrics-statsd/pull/27 (or a similar
solution) has been applied.