### PR TITLE
Multiple code improvements - squid:S1118, squid:S2925

### DIFF
--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/MetricPredicateTransformer.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/MetricPredicateTransformer.java
@@ -16,6 +16,8 @@ public class MetricPredicateTransformer
 {
     private static final Logger log = LoggerFactory.getLogger(MetricPredicateTransformer.class);
 
+    private MetricPredicateTransformer () {}
+
     static class PredicateConfigMetricPredicate implements MetricPredicate
     {
         final PredicateConfig predicate;

--- a/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/sample/NameTest.java
+++ b/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/sample/NameTest.java
@@ -77,7 +77,6 @@ public class NameTest
         }
         config.enableAll();
         counter.inc();
-        Thread.sleep(10000);
     }
 
 }

--- a/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/sample/SampleTest.java
+++ b/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/sample/SampleTest.java
@@ -48,7 +48,6 @@ public class SampleTest
         {
             counter.inc();
             meter.mark();
-            Thread.sleep(1000);
             log.debug("runLoop tick");
         }
         log.info("Done with sample data loop");

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/MetricFilterTransformer.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/MetricFilterTransformer.java
@@ -12,6 +12,8 @@ public class MetricFilterTransformer
 
     private static final Logger log = LoggerFactory.getLogger(MetricFilterTransformer.class);
 
+    private MetricFilterTransformer() {}
+
     private static class PredicateConfigFilter implements MetricFilter
     {
         final PredicateConfig predicate;

--- a/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/sample/NameTest.java
+++ b/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/sample/NameTest.java
@@ -81,7 +81,6 @@ public class NameTest
         }
         config.enableAll(registry);
         counter.inc();
-        Thread.sleep(10000);
     }
 
 }

--- a/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/sample/SampleTest.java
+++ b/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/sample/SampleTest.java
@@ -48,7 +48,6 @@ public class SampleTest
         {
             counter.inc();
             meter.mark();
-            Thread.sleep(1000);
             log.debug("runLoop tick");
         }
         log.info("Done with sample data loop");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S2925 - "Thread.sleep" should not be used in tests.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S2925
Please let me know if you have any questions.
George Kankava