### PR TITLE
Multiple code improvements - squid:S1066, squid:S1149, squid:UselessParenthesesCheck, squid:S1488, squid:UnusedPrivateMethod, squid:S3398, squid:S00115, squid:S1213, squid:S1068

### DIFF
--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractHostPortReporterConfig.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractHostPortReporterConfig.java
@@ -52,6 +52,25 @@ public abstract class AbstractHostPortReporterConfig extends AbstractMetricRepor
     private InetAddress localhost;
     private String resolvedPrefix;
 
+    /**
+     * Test constructor
+     *
+     * @param localhost
+     *            localhost
+     */
+    AbstractHostPortReporterConfig(InetAddress localhost) {
+        this.localhost = localhost;
+    }
+
+    public AbstractHostPortReporterConfig() {
+        try {
+            this.localhost = InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            // not expected to happen with properly configured system
+            log.error("Unable to get localhost", e);
+        }
+    }
+
     public List<HostPort> getHosts()
     {
         return hosts;
@@ -72,32 +91,8 @@ public abstract class AbstractHostPortReporterConfig extends AbstractMetricRepor
         this.hostsString = hostsString;
     }
 
-    private String getPrefix()
-    {
-        return prefix;
-    }
-
     public String getResolvedPrefix() {
         return resolvedPrefix;
-    }
-
-    /**
-     * Test constructor
-     *
-     * @param localhost
-     *            localhost
-     */
-    AbstractHostPortReporterConfig(InetAddress localhost) {
-        this.localhost = localhost;
-    }
-
-    public AbstractHostPortReporterConfig() {
-        try {
-            this.localhost = InetAddress.getLocalHost();
-        } catch (UnknownHostException e) {
-            // not expected to happen with properly configured system
-            log.error("Unable to get localhost", e);
-        }
     }
 
     public List<HostPort> parseHostString()

--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractReporterConfig.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractReporterConfig.java
@@ -38,8 +38,7 @@ public abstract class AbstractReporterConfig
     {
         Yaml yaml = new Yaml(new Constructor(clazz));
         InputStream input = new FileInputStream(new File(fileName));
-        T config = (T) yaml.load(input);
-        return config;
+        return (T) yaml.load(input);
     }
 
     // Based on com.yammer.dropwizard.validation.Validator

--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractRiemannReporterConfig.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractRiemannReporterConfig.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 public class AbstractRiemannReporterConfig extends AbstractHostPortReporterConfig
 {
-    private static final Logger log = LoggerFactory.getLogger(AbstractRiemannReporterConfig.class);
 
     protected String localHost;
     protected String prefix;

--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/GmondConfigParser.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/GmondConfigParser.java
@@ -39,10 +39,10 @@ public class GmondConfigParser
 {
     private static final Logger log = LoggerFactory.getLogger(GmondConfigParser.class);
 
-    private static final String cCommentPattern = "//.*?\n"; //
-    private static final String cppCommentPattern = "(?s)//*.*?/*/"; /* */
-    private static final String emptyLinePattern = "(?m)^\\s*\n";
-    private static final String udpSendPattern = "(?s)udp_send_channel\\s*\\{(.*?)\\}";
+    private static final String C_COMMENT_PATTERN = "//.*?\n"; //
+    private static final String CPP_COMMENT_PATTERN = "(?s)//*.*?/*/"; /* */
+    private static final String EMPTY_LINE_PATTERN = "(?m)^\\s*\n";
+    private static final String UDP_SEND_PATTERN = "(?s)udp_send_channel\\s*\\{(.*?)\\}";
 
 
     public List<HostPort> getGmondSendChannels(String fileName)
@@ -90,15 +90,14 @@ public class GmondConfigParser
 
     public String stripComments(String conf)
     {
-        String cFree = conf.replaceAll(cCommentPattern, "\n");
-        String cppFree = cFree.replaceAll(cppCommentPattern, "");
-        return cppFree;
+        String cFree = conf.replaceAll(C_COMMENT_PATTERN, "\n");
+        return cFree.replaceAll(CPP_COMMENT_PATTERN, "");
     }
 
 
     public String removeEmptyLines(String conf)
     {
-        return conf.replaceAll(emptyLinePattern, "");
+        return conf.replaceAll(EMPTY_LINE_PATTERN, "");
     }
 
 
@@ -106,7 +105,7 @@ public class GmondConfigParser
     {
         List<String> channelBlobs = new ArrayList<String>();
 
-        Matcher matcher = Pattern.compile(udpSendPattern).matcher(conf);
+        Matcher matcher = Pattern.compile(UDP_SEND_PATTERN).matcher(conf);
         while(matcher.find())
         {
             channelBlobs.add(matcher.group(1).trim());
@@ -127,20 +126,6 @@ public class GmondConfigParser
         return chan;
     }
 
-
-    // from lib/libgmond.c
-    /*
-static cfg_opt_t udp_send_channel_opts[] = {
-  CFG_STR("mcast_join", NULL, CFGF_NONE),
-  CFG_STR("mcast_if", NULL, CFGF_NONE),
-  CFG_STR("host", NULL, CFGF_NONE ),
-  CFG_INT("port", -1, CFGF_NONE ),
-  CFG_INT("ttl", 1, CFGF_NONE ),
-  CFG_STR("bind", NULL, CFGF_NONE),
-  CFG_BOOL("bind_hostname", 0, CFGF_NONE),
-  CFG_END()
-};
-    */
     public HostPort makeHostPort(Map<String,String> chan)
     {
         if (chan.containsKey("mcast_join") || chan.containsKey("mcast_if"))
@@ -151,7 +136,7 @@ static cfg_opt_t udp_send_channel_opts[] = {
         HostPort hp = null;
         try
         {
-            hp = new HostPort(chan.get("host"), (Integer.valueOf(chan.get("port"))));
+            hp = new HostPort(chan.get("host"), Integer.valueOf(chan.get("port")));
         }
         catch (Exception e)
         {
@@ -171,7 +156,7 @@ static cfg_opt_t udp_send_channel_opts[] = {
         {
             fr = new FileReader(fileName);
             br = new BufferedReader(fr);
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             String line = br.readLine();
             while (line != null)
             {

--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/PredicateConfig.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/PredicateConfig.java
@@ -27,7 +27,6 @@ import javax.validation.constraints.Size;
 
 public class PredicateConfig
 {
-    private static final Logger log = LoggerFactory.getLogger(PredicateConfig.class);
 
     // white ||, black &&
     @NotNull

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/ReporterConfig.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/ReporterConfig.java
@@ -246,54 +246,33 @@ public class ReporterConfig extends AbstractReporterConfig
     public boolean enableAll()
     {
         boolean enabled = false;
-        if (console != null)
+        if (console != null && enableConsole())
         {
-            if (enableConsole())
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (csv != null)
+        if (csv != null && enableCsv())
         {
-            if (enableCsv())
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (ganglia != null)
+        if (ganglia != null && enableGanglia())
         {
-            if (enableGanglia())
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (graphite != null)
+        if (graphite != null && enableGraphite())
         {
-            if (enableGraphite())
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (riemann != null)
+        if (riemann != null && enableRiemann())
         {
-            if (enableRiemann())
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (statsd != null)
+        if (statsd != null && enableStatsd())
         {
-            if (enableStatsd())
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (reporters != null)
+        if (reporters != null && enableReporters())
         {
-            if (enableReporters())
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
         if (!enabled)
         {

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/MetricFilterTransformer.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/MetricFilterTransformer.java
@@ -34,19 +34,20 @@ public class MetricFilterTransformer
                 return predicate.allowString(unqualifyMetricName(name));
             }
         }
-    }
 
-    private static String unqualifyMetricName(String name)
-    {
-        int location = name.lastIndexOf('.');
-        if (location < 0)
+        private static String unqualifyMetricName(String name)
         {
-            return name;
+            int location = name.lastIndexOf('.');
+            if (location < 0)
+            {
+                return name;
+            }
+            else
+            {
+                return name.substring(location + 1);
+            }
         }
-        else
-        {
-            return name.substring(location + 1);
-        }
+
     }
 
     public static MetricFilter generateFilter(PredicateConfig predicate)

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/ReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/ReporterConfig.java
@@ -219,47 +219,29 @@ public class ReporterConfig extends AbstractReporterConfig
     public boolean enableAll(MetricRegistry registry)
     {
         boolean enabled = false;
-        if (console != null)
+        if (console != null && enableConsole(registry))
         {
-            if (enableConsole(registry))
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (csv != null)
+        if (csv != null && enableCsv(registry))
         {
-            if (enableCsv(registry))
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (ganglia != null)
+        if (ganglia != null && enableGanglia(registry))
         {
-            if (enableGanglia(registry))
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (graphite != null)
+        if (graphite != null && enableGraphite(registry))
         {
-            if (enableGraphite(registry))
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (riemann != null)
+        if (riemann != null && enableRiemann(registry))
         {
-            if (enableRiemann(registry))
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
-        if (statsd != null)
+        if (statsd != null && enableStatsd(registry))
         {
-            if (enableStatsd(registry))
-            {
-                enabled = true;
-            }
+            enabled = true;
         }
         if (!enabled)
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1066 - Collapsible "if" statements should be merged.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:UnusedPrivateMethod - Unused private method should be removed.
squid:S3398 -  "private" methods called only by inner classes should be moved to those classes.
squid:S00115 - Constant names should comply with a naming convention.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1068 - Unused private fields should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:UnusedPrivateMethod
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1068
Please let me know if you have any questions.
George Kankava