### PR TITLE
2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.addthis.metrics</groupId>
   <artifactId>reporter-config</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <packaging>jar</packaging>
   <name>Metrics Reporter Config</name>
   <url>https://github.com/addthis/metrics-reporter-config</url>

--- a/src/main/java/com/addthis/metrics/reporter/config/CsvReporterConfig.java
+++ b/src/main/java/com/addthis/metrics/reporter/config/CsvReporterConfig.java
@@ -52,7 +52,22 @@ public class CsvReporterConfig extends AbstractReporterConfig
             boolean success = foutDir.mkdirs();
             if (!success)
             {
-                log.error("Failed to create directory {} for CsvReporter", outdir);
+                //Did we fail because the file already existed ?
+                //Ok , lets rename the existing file so we dont loose it
+                //and then re-create it.
+                if ( foutDir.exists() )
+                {
+                    String newName = foutDir.getAbsolutePath()+System.currentTimeMillis();
+                    log.error("metics: Failed to create directory {} for CsvReporter. It already exists. Renaming to {} ", outdir , newName );
+                    foutDir.renameTo( new File(newName));
+                    success = foutDir.mkdirs();
+                }
+            }
+
+            // checking for success again as it may have initially failed and the rename worked but we still failed to mkdir.
+            if (!success)
+            {
+                log.error("metrics: Failed to create or rename directory {} for CsvReporter.  ", outdir );
                 return false;
             }
             // static enable() methods omit the option of specifying a


### PR DESCRIPTION
This is to address  - https://github.com/addthis/metrics-reporter-config/issues/24

If the directory already exists then no metrics will gathered as we return false .  This is understandable as you may not want to overwrite existing metrics . 
The patch gets around this by renaming the existing directory to name+currentSystemtimeinmillis . 
and then recreated the original directory . 


