### PR TITLE
add prometheus support

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -161,6 +161,60 @@ Each substituted value gets sanitized by replacing all characters that
 are not allowed in the host name plus "-" with the underscore. The Ganglia reporter additionally
 supports the "groupPrefix" parameter. This will add a prefix to the Ganglia metric group.
 
+### Prometheus
+
+The Prometheus reporter does not support the prefix and predicate parameters and always
+operated on the fully qualified name. However, it supports name transformations via
+regular expressions to "group" multiple metrics into a single prometheus metric name
+and distinguish these using labels.
+
+For example, Apache Cassandra, emits table related metrics using qualified metric names
+like this: `org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system.paxos`,
+which means that this metric represents the disk space used by bloom filter for the
+table `paxos` in the keyspace `system`. The following config snippet transforms these
+metrics into a single metric for all tables. The metric type goes into the name,
+the keyspace name goes into the label `keyspace` and the table name goes into the
+label `table`.
+
+    prometheus:
+      -
+        mappings:
+          - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.(([^.]+)\.([^.]+))'
+            name: 'Table_$1'
+            labels:
+              - label: 'keyspace'
+                value: '$3'
+              - label: 'table'
+                value: '$2'
+
+It is also possible to exclude certain metrics using regular expressions.
+For example:
+
+    exclusions:
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.EstimatedPartitionCount\..+'
+
+The implementation will emit warnings if a qualified metric name does _not_ match
+any mapping or exclusions.
+
+Other important parameters are:
+
+    prometheus:
+      -
+        host: 'localhost'
+        port: 8088
+        ssl: false
+
+`host` defines the _local_ name or better IP address on which the _exporter_ shall
+listen.
+`port` defines the TCP port on which the _exporter_ shall listen.
+`ssl` allows usage of SSL using a self signed certificate.
+
+The implementation supports both prometheus' protobuf and text format.
+
+You need the following dependencies to use the prometheus exporter:
+* `protobuf-java-2.5.0.jar` (version=2.5.0, groupId=com.google.protobuf, artifactId=protobuf-java)
+* `simpleclient-0.0.14.jar` (version=0.0.14, groupId=io.prometheus, artifactId=simpleclient)
+
 ## Building
 
 Assuming you have [Apache Maven](http://maven.apache.org/) installed

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
     <dep.metrics2.version>2.2.0</dep.metrics2.version>
     <dep.metrics3.version>3.1.0</dep.metrics3.version>
     <dep.metrics-statsd.version>4.1.2</dep.metrics-statsd.version>
+    <dep.netty.version>4.0.37.Final</dep.netty.version>
+    <dep.prometheus-simpleclient.version>0.0.14</dep.prometheus-simpleclient.version>
+    <dep.protobuf.version>2.5.0</dep.protobuf.version>
     <project.build.targetJdk>1.6</project.build.targetJdk>
   </properties>
 

--- a/reporter-config-base/pom.xml
+++ b/reporter-config-base/pom.xml
@@ -24,4 +24,58 @@
     <name>metrics reporter config base</name>
     <description />
 
+    <dependencies>
+        <!-- prometheus -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${dep.protobuf.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <toolchains>
+                        <protobuf>
+                            <version>2.5.0</version>
+                        </protobuf>
+                    </toolchains>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <checkStaleness>true</checkStaleness>
+                    <outputDirectory>${project.build.directory}/generated-sources/protobuf</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractPrometheusReporterConfig.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractPrometheusReporterConfig.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics.reporter.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AbstractPrometheusReporterConfig extends AbstractMetricReporterConfig
+{
+    private static final Logger log = LoggerFactory.getLogger(AbstractPrometheusReporterConfig.class);
+
+    public boolean ssl;
+    public String host;
+    public int port;
+    public List<Mapping> mappings;
+    public List<Exclusion> exclusions;
+
+    public boolean isSsl()
+    {
+        return ssl;
+    }
+
+    public void setSsl(boolean ssl)
+    {
+        this.ssl = ssl;
+    }
+
+    public String getHost()
+    {
+        return host;
+    }
+
+    public void setHost(String host)
+    {
+        this.host = host;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    public void setPort(int port)
+    {
+        this.port = port;
+    }
+
+    public List<Mapping> getMappings()
+    {
+        return mappings;
+    }
+
+    public void setMappings(List<Mapping> mappings)
+    {
+        this.mappings = mappings;
+    }
+
+    public List<Exclusion> getExclusions()
+    {
+        return exclusions;
+    }
+
+    public void setExclusions(List<Exclusion> exclusions)
+    {
+        this.exclusions = exclusions;
+    }
+
+    public final static class Mapping {
+        public Pattern regex;
+        public String pattern;
+        public String name;
+        public List<Label> labels = new ArrayList<Label>();
+
+        public String getPattern()
+        {
+            return pattern;
+        }
+
+        public void setPattern(String pattern)
+        {
+            this.pattern = pattern;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public void setName(String name)
+        {
+            this.name = name;
+        }
+
+        public List<Label> getLabels()
+        {
+            return labels;
+        }
+
+        public void setLabels(List<Label> labels)
+        {
+            this.labels = labels;
+        }
+    }
+
+    public final static class Exclusion {
+        public Pattern regex;
+        public String pattern;
+
+        public String getPattern()
+        {
+            return pattern;
+        }
+
+        public void setPattern(String pattern)
+        {
+            this.pattern = pattern;
+        }
+    }
+
+    public final static class Label {
+        public String label;
+        public String value;
+
+        public String getLabel()
+        {
+            return label;
+        }
+
+        public void setLabel(String label)
+        {
+            this.label = label;
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        public void setValue(String value)
+        {
+            this.value = value;
+        }
+    }
+}

--- a/reporter-config-base/src/main/proto/prometheus.proto
+++ b/reporter-config-base/src/main/proto/prometheus.proto
@@ -1,0 +1,81 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package io.prometheus.client;
+option java_package = "io.prometheus.client";
+
+message LabelPair {
+    optional string name  = 1;
+    optional string value = 2;
+}
+
+enum MetricType {
+    COUNTER    = 0;
+    GAUGE      = 1;
+    SUMMARY    = 2;
+    UNTYPED    = 3;
+    HISTOGRAM  = 4;
+}
+
+message Gauge {
+    optional double value = 1;
+}
+
+message Counter {
+    optional double value = 1;
+}
+
+message Quantile {
+    optional double quantile = 1;
+    optional double value    = 2;
+}
+
+message Summary {
+    optional uint64   sample_count = 1;
+    optional double   sample_sum   = 2;
+    repeated Quantile quantile     = 3;
+}
+
+message Untyped {
+    optional double value = 1;
+}
+
+message Histogram {
+    optional uint64 sample_count = 1;
+    optional double sample_sum   = 2;
+    repeated Bucket bucket       = 3; // Ordered in increasing order of upper_bound, +Inf bucket is optional.
+}
+
+message Bucket {
+    optional uint64 cumulative_count = 1; // Cumulative in increasing order.
+    optional double upper_bound = 2;      // Inclusive.
+}
+
+message Metric {
+    repeated LabelPair label        = 1;
+    optional Gauge     gauge        = 2;
+    optional Counter   counter      = 3;
+    optional Summary   summary      = 4;
+    optional Untyped   untyped      = 5;
+    optional Histogram histogram    = 7;
+    optional int64     timestamp_ms = 6;
+}
+
+message MetricFamily {
+    optional string     name   = 1;
+    optional string     help   = 2;
+    optional MetricType type   = 3;
+    repeated Metric     metric = 4;
+}

--- a/reporter-config2/pom.xml
+++ b/reporter-config2/pom.xml
@@ -85,6 +85,25 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- prometheus -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${dep.netty.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${dep.protobuf.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>${dep.prometheus-simpleclient.version}</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
 </project>

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/ReporterConfig.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/ReporterConfig.java
@@ -23,6 +23,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.addthis.metrics.reporter.config.prometheus.PrometheusReporterConfig;
+
 
 // ser/d class.  May make a different abstract for commonalities
 
@@ -44,6 +46,8 @@ public class ReporterConfig extends AbstractReporterConfig
     private List<RiemannReporterConfig> riemann;
     @Valid
     private List<StatsDReporterConfig> statsd;
+    @Valid
+    private List<PrometheusReporterConfig> prometheus;
     @Valid
     private List<? extends MetricsReporterConfigTwo> reporters;
 
@@ -105,6 +109,16 @@ public class ReporterConfig extends AbstractReporterConfig
     public void setStatsd(List<StatsDReporterConfig> statsd)
     {
         this.statsd = statsd;
+    }
+
+    public List<PrometheusReporterConfig> getPrometheus()
+    {
+        return prometheus;
+    }
+
+    public void setPrometheus(List<PrometheusReporterConfig> prometheus)
+    {
+        this.prometheus = prometheus;
     }
 
     public List<? extends MetricsReporterConfigTwo> getReporters()
@@ -243,6 +257,24 @@ public class ReporterConfig extends AbstractReporterConfig
         return !failures;
     }
 
+    public boolean enablePrometheus()
+    {
+        boolean failures = false;
+        if (prometheus == null)
+        {
+            log.debug("Asked to enable prometheus, but it was not configured");
+            return false;
+        }
+        for (PrometheusReporterConfig prometheusConfig : prometheus)
+        {
+            if (!prometheusConfig.enable())
+            {
+                failures = true;
+            }
+        }
+        return !failures;
+    }
+
     public boolean enableAll()
     {
         boolean enabled = false;
@@ -267,6 +299,10 @@ public class ReporterConfig extends AbstractReporterConfig
             enabled = true;
         }
         if (statsd != null && enableStatsd())
+        {
+            enabled = true;
+        }
+        if (prometheus != null && enablePrometheus())
         {
             enabled = true;
         }

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/MetricInfo.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/MetricInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics.reporter.config.prometheus;
+
+import com.yammer.metrics.core.Metric;
+
+class MetricInfo<M extends Metric> {
+
+    final String sourceName;
+    final M metric;
+    final String[][] labels;
+
+    MetricInfo(String sourceName, M metric, String... labels) {
+        this.sourceName = sourceName;
+        this.metric = metric;
+
+        String[][] pairs = new String[labels.length / 2][];
+        for (int i = 0; i < labels.length / 2; i++) {
+            pairs[i] = new String[]{labels[i * 2], labels[i * 2 + 1]};
+        }
+        this.labels = pairs;
+    }
+
+    MetricInfo(String sourceName, M metric, String[][] labels) {
+        this.sourceName = sourceName;
+        this.metric = metric;
+        this.labels = labels;
+    }
+}

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/MetricsContainer.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/MetricsContainer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics.reporter.config.prometheus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.yammer.metrics.core.Metric;
+import io.prometheus.client.Prometheus;
+
+class MetricsContainer {
+    final String name;
+    final String help;
+    final Prometheus.MetricType type;
+    final String typeName;
+    private volatile List<MetricInfo> metrics = new ArrayList<MetricInfo>();
+
+    MetricsContainer(String name, String help, Prometheus.MetricType type) {
+        this.name = name;
+        this.help = help;
+        this.type = type;
+        this.typeName = type.name().toLowerCase();
+    }
+
+    List<MetricInfo> getMetrics() {
+        return metrics;
+    }
+
+    MetricsContainer addMetric(String s, Metric metric, String... labels) {
+        List<MetricInfo> copy = new ArrayList<MetricInfo>(metrics);
+        copy.add(new MetricInfo(s, metric, labels));
+        metrics = copy;
+        return this;
+    }
+
+    MetricsContainer addMetric(String s, Metric metric, String[][] labels) {
+        List<MetricInfo> copy = new ArrayList<MetricInfo>(metrics);
+        copy.add(new MetricInfo(s, metric, labels));
+        metrics = copy;
+        return this;
+    }
+
+    boolean removeMetric(String codahaleName) {
+        for (int i = 0; i < metrics.size(); i++) {
+            if (metrics.get(i).sourceName.equals(codahaleName)) {
+                List<MetricInfo> copy = new ArrayList<MetricInfo>(metrics);
+                copy.remove(i);
+                metrics = copy;
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/PrometheusReporter.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/PrometheusReporter.java
@@ -1,0 +1,555 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics.reporter.config.prometheus;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.activation.MimeType;
+import javax.activation.MimeTypeParseException;
+import javax.net.ssl.SSLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.addthis.metrics.reporter.config.AbstractPrometheusReporterConfig;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Meter;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.MetricsRegistryListener;
+import com.yammer.metrics.core.Timer;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContentCompressor;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.CharsetUtil;
+import io.prometheus.client.Prometheus;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaders.Names.DATE;
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+public class PrometheusReporter
+{
+    private static final Logger log = LoggerFactory.getLogger(PrometheusReporter.class);
+
+    private final PrometheusReporterConfig config;
+    private MetricsRegistry registry;
+    private MetricsListener metricsListener;
+
+    private volatile Map<String, MetricsContainer> metrics = new HashMap<String, MetricsContainer>();
+    private Channel nettyChannel;
+
+    public PrometheusReporter(MetricsRegistry registry, PrometheusReporterConfig config)
+    {
+        this.registry = registry;
+        this.config = config;
+
+        for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+            mapping.regex = Pattern.compile(mapping.pattern);
+            log.info("Initializing Prometheus metrics mapping with regex '{}'", mapping.regex);
+        }
+
+        for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+            exclusion.regex = Pattern.compile(exclusion.pattern);
+            log.info("Initializing Prometheus metrics exclusion with regex '{}'", exclusion.regex);
+        }
+
+        log.info("Setting up Prometheus metrics exporter on {} port {} and SSL {}", config.host, config.port, config.ssl ? "enabled" : "disabled");
+
+        metricsListener = new MetricsListener();
+        registry.addListener(metricsListener);
+
+        try {
+            setupNetty();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to setup metrics exporter", e);
+        }
+    }
+
+    private synchronized void addMetricsContainer(MetricsContainer container) {
+        Map<String, MetricsContainer> copy = new HashMap<String, MetricsContainer>(metrics);
+        copy.put(container.name, container);
+        metrics = copy;
+    }
+
+    private synchronized void removeMetricsContainer(String name) {
+        Map<String, MetricsContainer> copy = new HashMap<String, MetricsContainer>(metrics);
+        copy.remove(name);
+        metrics = copy;
+    }
+
+    /**
+     * Programmatic helper method to debug metric mappings.
+     * Pass in a <em>codahale</em> metric name and get the <em>mapped</em>
+     * name back.
+     *
+     * @param codahaleName codahale metric name
+     * @return mapped name or {@code null}, if not mapped
+     */
+    public String debugGetMappedName(String codahaleName) {
+        for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+            if (exclusion.regex.matcher(codahaleName).matches()) {
+                return null;
+            }
+        }
+        for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+            Matcher matcher = mapping.regex.matcher(codahaleName);
+            if (matcher.matches()) {
+                return matcher.replaceAll(mapping.name);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Programmatic helper method to debug metric mappings.
+     * Pass in a <em>codahale</em> metric name and get the <em>mapped</em>
+     * labels back.
+     *
+     * @param codahaleName codahale metric name
+     * @return mapped labels or {@code null}, if not mapped
+     */
+    public Map<String, String> debugGetMappedLabels(String codahaleName) {
+        for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+            if (exclusion.regex.matcher(codahaleName).matches()) {
+                return null;
+            }
+        }
+        for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+            Matcher matcher = mapping.regex.matcher(codahaleName);
+            if (matcher.matches()) {
+                Map<String, String> labels = new HashMap<String, String>();
+                for (AbstractPrometheusReporterConfig.Label label : mapping.labels) {
+                    labels.put(
+                    matcher.replaceAll(label.label),
+                    matcher.replaceAll(label.value));
+                }
+                return labels;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Stop the metrics exporter.
+     */
+    public void stop() {
+        log.info("Stopping Prometheus metrics exporter");
+
+        registry.removeListener(metricsListener);
+
+        if (nettyChannel != null)
+        {
+            nettyChannel.close();
+            nettyChannel.closeFuture().syncUninterruptibly();
+        }
+    }
+
+    private void sendMetrics(ResponseFormat responseFormat, OutputStream output) throws IOException
+    {
+        BufferedOutputStream buffered = new BufferedOutputStream(output);
+        Object out = responseFormat.createOutput(buffered);
+        for (MetricsContainer metricsContainer : metrics.values()) {
+            try {
+                if (log.isTraceEnabled()) {
+                    MetricsContainer container = metricsContainer;
+                    log.trace(".. sending container {} of type {}", container.name, container.type);
+                    for (MetricInfo metric : container.getMetrics()) {
+                        log.trace(".... metric {} ({})", metric.sourceName, metric.metric.getClass().getName());
+                        for (String[] label : metric.labels) {
+                            log.trace("....   label: {}={} ", label[0], label[1]);
+                        }
+                    }
+                }
+                responseFormat.writeMetric(metricsContainer, out);
+            } catch (Exception ex) {
+                log.error("Not including metrics for '" + metricsContainer.name + "' due to failure constructing these metrics", ex);
+            }
+        }
+        log.trace(".. metrics sent");
+        responseFormat.finish(out);
+        buffered.flush();
+    }
+
+    private void setupNetty() throws CertificateException, SSLException
+    {
+        final SslContext sslCtx;
+        if (config.ssl) {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            log.info("Setting up SSL context for certificate subject DN {} valid until {}", ssc.cert().getSubjectDN(), ssc.cert().getNotAfter());
+            sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
+        } else {
+            sslCtx = null;
+        }
+
+        final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        final EventLoopGroup workerGroup = new NioEventLoopGroup();
+
+        this.nettyChannel = new ServerBootstrap()
+                            .option(ChannelOption.SO_BACKLOG, 1024)
+                            .group(bossGroup, workerGroup)
+                            .channel(NioServerSocketChannel.class)
+                            .childHandler(new ServerInitializer(sslCtx))
+                            .bind(config.host, config.port).syncUninterruptibly().channel();
+
+        nettyChannel.closeFuture().addListener(new ChannelFutureListener()
+        {
+            public void operationComplete(ChannelFuture future) throws Exception
+            {
+                log.info("Shutting down listener");
+                bossGroup.shutdownGracefully();
+                workerGroup.shutdownGracefully();
+            }
+        });
+    }
+
+    private class ServerInitializer extends ChannelInitializer<SocketChannel>
+    {
+
+        private final SslContext sslCtx;
+
+        private ServerInitializer(SslContext sslCtx) {
+            this.sslCtx = sslCtx;
+        }
+
+        @Override
+        public void initChannel(SocketChannel ch) {
+            ChannelPipeline p = ch.pipeline();
+            if (sslCtx != null) {
+                p.addLast(sslCtx.newHandler(ch.alloc()));
+            }
+            p.addLast("decoder", new HttpRequestDecoder());
+            p.addLast("encoder", new HttpResponseEncoder());
+            p.addLast("compressor", new HttpContentCompressor());
+            p.addLast("handler", new ServerHandler());
+        }
+    }
+
+    private class ServerHandler extends ChannelInboundHandlerAdapter
+    {
+        @Override
+        public void channelRead(final ChannelHandlerContext ctx, Object msg) {
+            if (msg instanceof HttpRequest) {
+                HttpRequest req = (HttpRequest) msg;
+
+                log.debug("HTTP request {}", req);
+
+                if (!req.getDecoderResult().isSuccess()) {
+                    sendError(ctx, BAD_REQUEST);
+                    return;
+                }
+
+                if (req.getMethod() != GET) {
+                    sendError(ctx, METHOD_NOT_ALLOWED);
+                    return;
+                }
+
+                if (HttpHeaders.is100ContinueExpected(req)) {
+                    ctx.write(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE));
+                }
+
+                ResponseFormat responseFormat = responseFormat(req);
+
+                boolean keepAlive = HttpHeaders.isKeepAlive(req);
+                HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
+                HttpHeaders.setHeader(response, CONTENT_TYPE, responseFormat.contentType());
+                HttpHeaders.setDateHeader(response, DATE, new Date());
+                HttpHeaders.setTransferEncodingChunked(response);
+
+                if (keepAlive) {
+                    response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                }
+
+                ctx.write(response);
+
+                log.debug("Sending response as {}", responseFormat.contentType());
+
+                try {
+                    sendMetrics(responseFormat, new OutputStream() {
+                        @Override
+                        public void write(byte[] b, int off, int len) throws IOException {
+                            ctx.write(new DefaultHttpContent(Unpooled.wrappedBuffer(b, off, len)));
+                        }
+
+                        @Override
+                        public void write(int b) throws IOException {
+                            throw new UnsupportedOperationException();
+                        }
+                    });
+                } catch (Throwable e) {
+                    log.info("Error during response processing", e);
+                    sendError(ctx, INTERNAL_SERVER_ERROR);
+                }
+
+                ChannelFuture lastContentFuture = ctx.write(LastHttpContent.EMPTY_LAST_CONTENT);
+                if (!keepAlive) {
+                    lastContentFuture.addListener(ChannelFutureListener.CLOSE);
+                }
+
+                ctx.flush();
+            }
+        }
+
+        private void sendError(ChannelHandlerContext ctx, HttpResponseStatus status) {
+            FullHttpResponse response = new DefaultFullHttpResponse(
+                                                                   HTTP_1_1, status, Unpooled.copiedBuffer("Failure: " + status + "\r\n", CharsetUtil.UTF_8));
+            response.headers().set(CONTENT_TYPE, "text/plain; charset=UTF-8");
+
+            // Close the connection as soon as the error message is sent.
+            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+        }
+
+        private ResponseFormat responseFormat(HttpRequest req) {
+            ResponseFormat responseFormat = ResponseFormat.TEXT;
+            String accept = HttpHeaders.getHeader(req, "Accept");
+            if (accept != null) {
+                double qText = 0.0d;
+                double qProtobuf = 0.0d;
+                for (StringTokenizer st = new StringTokenizer(accept, ","); st.hasMoreTokens(); ) {
+                    try {
+                        MimeType mimeType = new MimeType(st.nextToken());
+                        String s2 = mimeType.getPrimaryType();
+                        if (s2.equals("text"))
+                        {
+                            String s = mimeType.getSubType();
+                            if (s.equals("*") || s.equals("plain"))
+                            {
+                                qText = qEval(qText, mimeType);
+                            }
+                        }
+                        else if (s2.equals("application"))
+                        {
+                            String s1 = mimeType.getSubType();
+                            if (s1.equals("vnd.google.protobuf") || s1.equals("octet-stream"))
+                            {
+                                if ("delimited".equals(mimeType.getParameter("encoding")) &&
+                                    "io.prometheus.client.MetricFamily".equals(mimeType.getParameter("proto")))
+                                    qProtobuf = qEval(qProtobuf, mimeType);
+                            }
+                        }
+                    } catch (MimeTypeParseException e) {
+                        // just ignore this
+                    }
+                }
+                if (qProtobuf > qText)
+                    responseFormat = ResponseFormat.PROTOBUF;
+            }
+            log.trace("Chosen response format {} for HTTP Accept:{}", responseFormat.contentType(), accept);
+            return responseFormat;
+        }
+
+        private double qEval(double currentQ, MimeType mimeType) {
+            String sq = mimeType.getParameter("q");
+            double q = sq != null ? Double.parseDouble(sq.trim()) : 0.01d;
+            return Math.max(q, currentQ);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            cause.printStackTrace();
+            ctx.close();
+        }
+    }
+
+    private class MetricsListener implements MetricsRegistryListener
+    {
+        private final Pattern VALIDATION_PATTERN = Pattern.compile("[a-zA-Z_:][a-zA-Z0-9_:]*");
+
+        private synchronized void unregisterMetric(String codahaleName) {
+            for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+                if (exclusion.regex.matcher(codahaleName).matches()) {
+                    return;
+                }
+            }
+
+            for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+                Matcher matcher = mapping.regex.matcher(codahaleName);
+                if (matcher.matches()) {
+                    String name = matcher.replaceAll(mapping.name);
+
+                    MetricsContainer container = metrics.get(name);
+                    if (container.removeMetric(codahaleName)) {
+                        return;
+                    }
+                }
+            }
+
+            String name = convert(codahaleName);
+            removeMetricsContainer(name);
+        }
+
+        private synchronized void registerMetric(String codahaleName, Metric metric) {
+            for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+                if (exclusion.regex.matcher(codahaleName).matches()) {
+                    return;
+                }
+            }
+
+            Prometheus.MetricType type;
+            if (metric instanceof Gauge) {
+                type = Prometheus.MetricType.GAUGE;
+            } else if ((metric instanceof Counter) || (metric instanceof Meter)) {
+                type = Prometheus.MetricType.COUNTER;
+            } else if ((metric instanceof Histogram) || (metric instanceof Timer)) {
+                type = Prometheus.MetricType.SUMMARY;
+            } else {
+                throw new UnsupportedOperationException("Unknown metric of type " + metric.getClass().getName());
+            }
+
+            for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+                Matcher matcher = mapping.regex.matcher(codahaleName);
+                if (matcher.matches()) {
+                    log.debug("{} matches {}", codahaleName, mapping.pattern);
+                    String name = matcher.replaceAll(mapping.name);
+
+                    List<String[]> labels = new ArrayList<String[]>();
+                    for (AbstractPrometheusReporterConfig.Label label : mapping.labels) {
+                        labels.add(new String[]{
+                        matcher.replaceAll(label.label),
+                        matcher.replaceAll(label.value)
+                        });
+                    }
+
+                    if (!VALIDATION_PATTERN.matcher(name).matches())
+                        log.warn("Invalid Prometheus metric name '{}' (from '{}')", name, codahaleName);
+                    else {
+                        MetricsContainer container = metrics.get(name);
+                        if (container == null) {
+                            addMetricsContainer(container = new MetricsContainer(name, "from codahale", type));
+                        } else {
+                            if (container.type != type) {
+                                log.error("Existing metrics with name '{}' are of type '{}' but metric to be registered '{}' is of type '{}'",
+                                             container.name, container.type, codahaleName, type);
+                                return;
+                            }
+                        }
+                        container.addMetric(codahaleName, metric, labels.toArray(new String[labels.size()][]));
+                    }
+
+                    return;
+                }
+            }
+
+            log.info("No matching metric mapping for '{}'", codahaleName);
+            String name = convert(codahaleName);
+            MetricsContainer container = new MetricsContainer(name, "from codahale", type);
+            container.addMetric(codahaleName, metric);
+            addMetricsContainer(container);
+        }
+
+        private String convert(String s) {
+            StringBuilder sb = new StringBuilder(s.length());
+            for (int i = 0; i < s.length(); i++) {
+                char c = s.charAt(i);
+                switch (c) {
+                    case '.':
+                        c = '_';
+                        break;
+                    case '-':
+                        c = '_';
+                        break;
+                }
+                sb.append(c);
+            }
+            s = sb.toString();
+            if (!VALIDATION_PATTERN.matcher(s).matches())
+                log.warn("Metric name {} does not validate", s);
+            return s;
+        }
+
+        @Override
+        public void onMetricAdded(MetricName metricName, Metric metric)
+        {
+            registerMetric(fullName(metricName), metric);
+        }
+
+        @Override
+        public void onMetricRemoved(MetricName metricName)
+        {
+            unregisterMetric(fullName(metricName));
+        }
+
+        private String fullName(MetricName metricName)
+        {
+            return name( metricName.getGroup(),  metricName.getType(),  metricName.getName(),  metricName.getScope());
+        }
+
+        public String name(String name, String... names) {
+            final StringBuilder builder = new StringBuilder();
+            append(builder, name);
+            if (names != null) {
+                for (String s : names) {
+                    append(builder, s);
+                }
+            }
+            return builder.toString();
+        }
+
+        private void append(StringBuilder builder, String part) {
+            if (part != null && !part.isEmpty()) {
+                if (builder.length() > 0) {
+                    builder.append('.');
+                }
+                builder.append(part);
+            }
+        }
+    }
+}

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/PrometheusReporterConfig.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/PrometheusReporterConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics.reporter.config.prometheus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.addthis.metrics.reporter.config.AbstractPrometheusReporterConfig;
+import com.addthis.metrics.reporter.config.MetricsReporterConfigTwo;
+import com.yammer.metrics.Metrics;
+
+public class PrometheusReporterConfig extends AbstractPrometheusReporterConfig implements MetricsReporterConfigTwo
+{
+    private static final Logger log = LoggerFactory.getLogger(PrometheusReporterConfig.class);
+
+    private PrometheusReporter reporter;
+
+    @Override
+    public boolean enable()
+    {
+        boolean success = setup("com.addthis.metrics.reporter.config.prometheus.PrometheusReporter") &&
+                          setup("com.google.protobuf.ProtocolMessageEnum") &&
+                          setup("io.prometheus.client.Collector");
+        if (!success)
+        {
+            return false;
+        }
+
+        try
+        {
+            enableMetrics3();
+        }
+        catch (Exception e)
+        {
+            log.error("Faliure while enabling PrometheusReporter", e);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void enableMetrics3()
+    {
+        reporter = new PrometheusReporter(Metrics.defaultRegistry(), this);
+    }
+
+    private boolean setup(String className)
+    {
+        if (!isClassAvailable(className))
+        {
+            log.error("Tried to enable PrometheusReporter, but class {} was not found", className);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Stop the metrics exporter.
+     */
+    public void stop() {
+        if (reporter != null)
+        {
+            reporter.stop();
+        }
+    }
+
+    public PrometheusReporter getReporter()
+    {
+        return reporter;
+    }
+}

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/ResponseFormat.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/prometheus/ResponseFormat.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.metrics.reporter.config.prometheus;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.CodedOutputStream;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Metered;
+import com.yammer.metrics.core.Sampling;
+import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.stats.Snapshot;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Prometheus;
+
+public interface ResponseFormat<O> {
+
+    double FACTOR_TIMER = 1.0d / TimeUnit.SECONDS.toNanos(1L);
+
+    String contentType();
+
+    void writeMetric(MetricsContainer metrics, O writer) throws IOException;
+
+    O createOutput(OutputStream output);
+
+    void finish(O output) throws IOException;
+
+    ResponseFormat TEXT = new TextFormat();
+    ResponseFormat PROTOBUF = new ProtobufFormat();
+
+    final class TextFormat implements ResponseFormat<Writer> {
+        private static final Logger LOGGER = LoggerFactory.getLogger(TextFormat.class);
+        private static final String CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
+
+        @Override
+        public String contentType() {
+            return CONTENT_TYPE_004;
+        }
+
+        @Override
+        public Writer createOutput(OutputStream output) {
+            return new OutputStreamWriter(output);
+        }
+
+        @Override
+        public void finish(Writer output) throws IOException {
+            output.flush();
+        }
+
+        @Override
+        public void writeMetric(MetricsContainer metrics, Writer writer) throws IOException {
+            writer.write("# HELP " + metrics.name + " from dropwizard/codahale\n");
+            writer.write("# TYPE " + metrics.name + " " + metrics.typeName + "\n");
+
+            for (MetricInfo metric : metrics.getMetrics()) {
+                switch (metrics.type) {
+                    case GAUGE:
+                    case COUNTER:
+                        double value = 0;
+                        if (metric.metric instanceof Gauge) {
+                            Object obj = ((Gauge) metric.metric).value();
+                            if (obj instanceof Number) {
+                                value = ((Number) obj).doubleValue();
+                            } else if (obj instanceof Boolean) {
+                                value = ((Boolean) obj) ? 1 : 0;
+                            } else {
+                                continue;
+                            }
+                        } else if (metric.metric instanceof Metered) {
+                            value = ((Metered) metric.metric).count();
+                        } else if (metric.metric instanceof Counter) {
+                            value = ((Counter) metric.metric).count();
+                        }
+                        writer.write(metrics.name);
+                        writer.write(textLabels(metric.labels, true));
+                        writer.write(" ");
+                        writer.write(Collector.doubleToGoString(value) + "\n");
+                        break;
+                    case SUMMARY:
+                        boolean isTimer = metric.metric instanceof Timer;
+                        double factor = isTimer ? FACTOR_TIMER : 1.0d;
+
+                        Snapshot snapshot = ((Sampling) metric.metric).getSnapshot();
+
+                        double sum = 0;
+                        for (double i : snapshot.getValues()) {
+                            sum += i;
+                        }
+
+                        String labels = textLabels(metric.labels, false);
+                        try {
+                            sampleValue(writer, metrics.name, labels, "0.5", snapshot.getMedian() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.75", snapshot.get75thPercentile() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.95", snapshot.get95thPercentile() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.98", snapshot.get98thPercentile() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.99", snapshot.get99thPercentile() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.999", snapshot.get999thPercentile() * factor);
+                            sampleValue(writer, metrics.name + "_count", labels, null, ((Counter) metric.metric).count());
+                            sampleValue(writer, metrics.name + "_sum", labels, null, sum * factor);
+                        }
+                        catch (Exception e) {
+                            LOGGER.warn("Failed to build metric values for {} ({}) due to {}", metrics.name, metric.sourceName, e.toString());
+                        }
+                        break;
+                }
+            }
+        }
+
+        private String textLabels(String[][] labels, boolean withBrackets) {
+            if (labels.length == 0)
+                return "";
+            StringBuilder sb = new StringBuilder();
+            if (withBrackets)
+                sb.append('{');
+            for (String[] label : labels) {
+                sb.append(label[0]).append('=').append(escapeLabelValue(label[1])).append(',');
+            }
+            if (withBrackets)
+                sb.append('}');
+            return sb.toString();
+        }
+
+        static String escapeLabelValue(String s) {
+            return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+        }
+
+        private void sampleValue(Writer writer, String name, String labels, String quant, double v) throws IOException {
+            writer.write(name);
+            if (quant != null || labels != null)
+                writer.write('{');
+            if (labels != null) {
+                writer.write(labels);
+            }
+            if (quant != null) {
+                writer.write("quantile=\"");
+                writer.write(quant);
+                writer.write("\"");
+            }
+            if (quant != null || labels != null)
+                writer.write('}');
+            writer.write(' ');
+            writer.write(Collector.doubleToGoString(v));
+            writer.write('\n');
+        }
+    }
+
+    final class ProtobufFormat implements ResponseFormat<CodedOutputStream> {
+        private static final Logger LOGGER = LoggerFactory.getLogger(ProtobufFormat.class);
+        private static final String CONTENT_TYPE_004 = "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited";
+
+        @Override
+        public String contentType() {
+            return CONTENT_TYPE_004;
+        }
+
+        @Override
+        public void finish(CodedOutputStream output) throws IOException {
+            output.flush();
+        }
+
+        @Override
+        public CodedOutputStream createOutput(OutputStream output) {
+            return CodedOutputStream.newInstance(output);
+        }
+
+        @Override
+        public void writeMetric(MetricsContainer metrics, CodedOutputStream writer) throws IOException {
+            Prometheus.MetricFamily.Builder builder = Prometheus.MetricFamily.newBuilder().
+                    setHelp("from dropwizard/codahale " + metrics.name).
+                    setName(metrics.name).
+                    setType(metrics.type);
+
+            for (MetricInfo metric : metrics.getMetrics()) {
+                switch (metrics.type) {
+                    case GAUGE:
+                        Object obj = ((Gauge) metric.metric).value();
+                        double value;
+                        if (obj instanceof Number) {
+                            value = ((Number) obj).doubleValue();
+                        } else if (obj instanceof Boolean) {
+                            value = ((Boolean) obj) ? 1 : 0;
+                        } else {
+                            return;
+                        }
+                        Prometheus.Metric.Builder metricBuilder = builder.addMetricBuilder();
+                        addLabels(metricBuilder, metric);
+                        metricBuilder.setGauge(Prometheus.Gauge.newBuilder().setValue(value));
+                        break;
+                    case COUNTER:
+                        long v = ((Counter) metric.metric).count();
+                        metricBuilder = builder.addMetricBuilder();
+                        addLabels(metricBuilder, metric);
+                        metricBuilder.setCounter(Prometheus.Counter.newBuilder().setValue(v));
+                        break;
+                    case SUMMARY:
+                        boolean isTimer = metric.metric instanceof Timer;
+                        double factor = isTimer ? FACTOR_TIMER : 1.0d;
+                        fromSnapshotAndCount(builder, metrics, metric,
+                                ((Sampling) metric.metric).getSnapshot(),
+                                ((Counter) metric.metric).count(), factor);
+                        break;
+                }
+// TODO somehow possible to add mean, one-minute, five-minute, fifteen-minute rates along WITH the histogram/meter ?
+//                if (metric.metric instanceof Metered) {
+//                    Metered metered = (Metered) metric.metric;
+//                    metered.getMeanRate();
+//                    metered.getOneMinuteRate();
+//                    metered.getFiveMinuteRate();
+//                    metered.getFifteenMinuteRate();
+//                }
+            }
+
+            if (builder.getMetricCount() > 0) {
+                writer.writeMessageNoTag(builder.build());
+            }
+        }
+
+        private void addLabels(Prometheus.Metric.Builder metricBuilder, MetricInfo metric) {
+            for (String[] label : metric.labels) {
+                metricBuilder.addLabelBuilder()
+                        .setName(label[0])
+                        .setValue(label[1]);
+            }
+        }
+
+        private void fromSnapshotAndCount(Prometheus.MetricFamily.Builder builder, MetricsContainer metrics, MetricInfo metric, Snapshot snapshot, long count, double factor) {
+            double sum = 0;
+            for (double i : snapshot.getValues()) {
+                sum += i;
+            }
+
+            try {
+                Prometheus.Summary.Builder summaryBuilder = Prometheus.Summary.newBuilder();
+                summaryBuilder.addQuantileBuilder().setQuantile(.5d).setValue(snapshot.getMedian() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.75d).setValue(snapshot.get75thPercentile() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.95d).setValue(snapshot.get95thPercentile() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.98d).setValue(snapshot.get98thPercentile() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.99d).setValue(snapshot.get99thPercentile() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.999d).setValue(snapshot.get999thPercentile() * factor);
+                summaryBuilder.setSampleCount(count);
+                summaryBuilder.setSampleSum(sum * factor);
+                Prometheus.Metric.Builder metricBuilder = builder.addMetricBuilder();
+                addLabels(metricBuilder, metric);
+                metricBuilder.setSummary(summaryBuilder);
+            }
+            catch (Exception e) {
+                LOGGER.warn("Failed to build metric values for {} ({}) due to {}", metrics.name, metric.sourceName, e.toString());
+            }
+        }
+    }
+}

--- a/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/PrometheusConfigTest.java
+++ b/reporter-config2/src/test/java/com/addthis/metrics/reporter/config/PrometheusConfigTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics.reporter.config;
+
+import java.net.URL;
+
+import org.junit.Test;
+
+import com.addthis.metrics.reporter.config.prometheus.PrometheusReporterConfig;
+
+public class PrometheusConfigTest
+{
+    @Test
+    public void parseCassandraConfig() throws Exception
+    {
+        URL url = PrometheusConfigTest.class.getResource("/prometheus/prometheus-cassandra.yaml");
+        String file = url.getFile();
+        ReporterConfig config = ReporterConfig.loadFromFile(file);
+        try
+        {
+            for (PrometheusReporterConfig prometheusReporterConfig : config.getPrometheus())
+            {
+                // bind to a random port
+                prometheusReporterConfig.setPort(0);
+            }
+
+            config.enableAll();
+        }
+        finally
+        {
+            for (PrometheusReporterConfig prometheusReporterConfig : config.getPrometheus())
+            {
+                prometheusReporterConfig.stop();
+            }
+        }
+    }
+}

--- a/reporter-config2/src/test/resources/prometheus/prometheus-cassandra.yaml
+++ b/reporter-config2/src/test/resources/prometheus/prometheus-cassandra.yaml
@@ -1,0 +1,198 @@
+prometheus:
+  -
+    host: 'localhost'
+    port: 8088
+    ssl: false
+
+    exclusions:
+      # EstimatedPartitionCount is a very expensive operation which deserializes compaction stats
+      # from all sstables on invocation.
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.EstimatedPartitionCount\..+'
+      # following is for Cassandra < 3.0, since types of metrics vary (GAUGE + COUNTER)
+      - pattern: 'org\.apache\.cassandra\.metrics\.ThreadPools\.TotalBlockedTasks\..+'
+      # following is for Cassandra < 3.0, since types of metrics vary (GAUGE + COUNTER)
+      - pattern: 'org\.apache\.cassandra\.metrics\.ThreadPools\.CurrentlyBlockedTasks\..+'
+
+    # Codahale metrics name mappigns follow.
+    # These mappings group equal metrics of different targets under one name but
+    # specify labels to distinguish them.
+    #
+    # For example, the following mapping exports one name 'BloomFilterDiskSpaceUsed'
+    # containing the values for all tables using different labels.
+    mappings:
+      # example: org.apache.cassandra.metrics.keyspace.CasProposeLatency.workloads
+      - pattern: 'org\.apache\.cassandra\.metrics\.keyspace\.([^.]+)\.([^.]+)'
+        name: 'Keyspace_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$2'
+
+      #
+      # Cassandra >= 3.0
+      #
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.all
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.all$'
+        name: 'TableAll_$1'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system.paxos
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.(([^.]+)\.([^.]+))'
+        name: 'Table_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$3'
+          - label: 'table'
+            value: '$2'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.([^.]+)'
+        name: 'TableKeyspace_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$2'
+
+      #
+      # Cassandra < 3.0
+      #
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.all
+      - pattern: 'org\.apache\.cassandra\.metrics\.ColumnFamily\.([^.]+)\.all$'
+        name: 'TableAll_$1'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system.paxos
+      - pattern: 'org\.apache\.cassandra\.metrics\.ColumnFamily\.([^.]+)\.(([^.]+)\.([^.]+))'
+        name: 'Table_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$3'
+          - label: 'table'
+            value: '$2'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system
+      - pattern: 'org\.apache\.cassandra\.metrics\.ColumnFamily\.([^.]+)\.([^.]+)'
+        name: 'TableKeyspace_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$2'
+
+      # example: org.apache.cassandra.metrics.Connection.TotalTimeouts
+      - pattern: 'org\.apache\.cassandra\.metrics\.Connection\.TotalTimeouts'
+        name: 'ConnectionTotalTimeouts'
+      # example: org.apache.cassandra.metrics.Connection.Timeouts.10.240.0.7
+      - pattern: 'org\.apache\.cassandra\.metrics\.Connection\.Timeouts\.(.+)'
+        name: 'ConnectionTimeouts'
+        labels:
+          - label: 'endpoint'
+            value: '$1'
+      # example: org.apache.cassandra.metrics.Connection.LargeMessagePendingTasks.10.240.0.7
+      - pattern: 'org\.apache\.cassandra\.metrics\.Connection\.([^.]+)\.(.+)'
+        name: 'Connection$1'
+        labels:
+          - label: 'endpoint'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.ThreadPools.ActiveTasks.internal.PendingRangeCalculator
+      - pattern: 'org\.apache\.cassandra\.metrics\.ThreadPools\.([^.]+)\.([^.]+)\.([^.]+)'
+        name: 'ThreadPools_$1'
+        labels:
+          - label: 'pool'
+            value: '$3'
+          - label: 'type'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.Cache.HitRate.CounterCache
+      - pattern: 'org\.apache\.cassandra\.metrics\.Cache\.([^.]+)\.([^.]+)'
+        name: 'Cache_$1'
+        labels:
+          - label: 'cache'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.DroppedMessage.InternalDroppedLatency.PAGED_RANGE
+      - pattern: 'org\.apache\.cassandra\.metrics\.DroppedMessage\.([^.]+)\.(.+)'
+        name: 'DroppedMessage_$1'
+        labels:
+          - label: 'message'
+            value: '$2'
+    
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.Compaction\.(.+)'
+        name: 'Compaction_$1'
+    
+      # example: org.apache.cassandra.metrics.CommitLog.WaitingOnSegmentAllocation
+      - pattern: 'org\.apache\.cassandra\.metrics\.CommitLog\.(.+)'
+        name: 'CommitLog_$1'
+    
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.BufferPool\.(.+)'
+        name: 'BufferPool_$1'
+    
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.Storage\.(.+)'
+        name: 'Storage_$1'
+    
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.CQL\.(.+)'
+        name: 'CQL_$1'
+    
+      # example: org.apache.cassandra.metrics.ClientRequest.ViewPendingMutations.ViewWrite
+      - pattern: 'org\.apache\.cassandra\.metrics\.ClientRequest\.([^.]+)\.([^.]+)'
+        name: 'ClientRequest_$1'
+        labels:
+          - label: 'sensor'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.Client.RequestsInFlight
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.RequestsInFlight'
+        name: 'ClientRequestsInFlight'
+    
+      # example: org.apache.cassandra.metrics.Client.RequestCount
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.RequestCount'
+        name: 'ClientRequestCount'
+    
+      # example: org.apache.cassandra.metrics.Client.Message.QUERY
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.Message\.(.+)'
+        name: 'ClientMessage'
+        labels:
+          - label: 'message'
+            value: '$1'
+    
+      # example: org.apache.cassandra.metrics.Client.Error.READ_TIMEOUT
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.Error\.(.+)'
+        name: 'ClientError'
+        labels:
+          - label: 'error'
+            value: '$1'
+    
+      # example: org.apache.cassandra.metrics.Client.connectedNativeClients
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.(.+)'
+        name: 'Client_$1'
+    
+      # example: org.apache.cassandra.metrics.Index.IndexInfoCount.RowIndexEntry
+      - pattern: 'org\.apache\.cassandra\.metrics\.Index\.([^.]+)\.([^.]+)'
+        name: 'Index_$1'
+        labels:
+          - label: 'type'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.ReadRepair.RepairedBlocking
+      - pattern: 'org\.apache\.cassandra\.metrics\.ReadRepair\.(.+)'
+        name: 'ReadRepair_$1'
+    
+      # example: org.apache.cassandra.metrics.DirectMemory.Allocated
+      - pattern: 'org\.apache\.cassandra\.metrics\.DirectMemory\.(.+)'
+        name: 'DirectMemory_$1'
+    
+    # example org.apache.cassandra.metrics.HintedHandOffManager.Hints_created-10.240.0.10
+      - pattern: 'org\.apache\.cassandra\.metrics\.HintedHandOffManager\.([^-]+)-(.+)'
+        name: '$1'
+        labels:
+          - label: 'endpoint'
+            value: '$2'
+    # example org.apache.cassandra.metrics.Messaging.CrossNodeLatency
+      - pattern: 'org\.apache\.cassandra\.metrics\.Messaging\.CrossNodeLatency'
+        name: 'CrossNodeLatency'
+
+    #
+    # Cassandra < 3.0
+    #
+      - pattern: 'org\.apache\.cassandra\.metrics\.ClientRequestMetrics\.(.+)'
+        name: 'ClientRequestMetrics_$1'
+    #
+    # Cassandra < 3.0
+    #
+      - pattern: 'org\.apache\.cassandra\.metrics\.FileCache\.(.+)'
+        name: 'FileCache_$1'

--- a/reporter-config2/src/test/resources/prometheus/prometheus.yaml
+++ b/reporter-config2/src/test/resources/prometheus/prometheus.yaml
@@ -1,0 +1,11 @@
+prometheus:
+  -
+    host: 'localhost'
+    port: 8088
+    ssl: false
+    mappings:
+      # default mapping, expose the metrics using the metrics name used in codahale
+      - pattern: '(.+)'
+        name: '$1'
+    #exclusions:
+      #- pattern: 'regex-pattern-to-exclude-a-metrics'

--- a/reporter-config3/pom.xml
+++ b/reporter-config3/pom.xml
@@ -68,6 +68,24 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- prometheus -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${dep.netty.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${dep.protobuf.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>${dep.prometheus-simpleclient.version}</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
-
 </project>

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/MetricInfo.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/MetricInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics3.reporter.config.prometheus;
+
+import com.codahale.metrics.Metric;
+
+class MetricInfo<M extends Metric> {
+
+    final String sourceName;
+    final M metric;
+    final String[][] labels;
+
+    MetricInfo(String sourceName, M metric, String... labels) {
+        this.sourceName = sourceName;
+        this.metric = metric;
+
+        String[][] pairs = new String[labels.length / 2][];
+        for (int i = 0; i < labels.length / 2; i++) {
+            pairs[i] = new String[]{labels[i * 2], labels[i * 2 + 1]};
+        }
+        this.labels = pairs;
+    }
+
+    MetricInfo(String sourceName, M metric, String[][] labels) {
+        this.sourceName = sourceName;
+        this.metric = metric;
+        this.labels = labels;
+    }
+}

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/MetricsContainer.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/MetricsContainer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics3.reporter.config.prometheus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.codahale.metrics.Metric;
+import io.prometheus.client.Prometheus;
+
+class MetricsContainer {
+    final String name;
+    final String help;
+    final Prometheus.MetricType type;
+    final String typeName;
+    private volatile List<MetricInfo> metrics = new ArrayList<MetricInfo>();
+
+    MetricsContainer(String name, String help, Prometheus.MetricType type) {
+        this.name = name;
+        this.help = help;
+        this.type = type;
+        this.typeName = type.name().toLowerCase();
+    }
+
+    List<MetricInfo> getMetrics() {
+        return metrics;
+    }
+
+    MetricsContainer addMetric(String s, Metric metric, String... labels) {
+        List<MetricInfo> copy = new ArrayList<MetricInfo>(metrics);
+        copy.add(new MetricInfo(s, metric, labels));
+        metrics = copy;
+        return this;
+    }
+
+    MetricsContainer addMetric(String s, Metric metric, String[][] labels) {
+        List<MetricInfo> copy = new ArrayList<MetricInfo>(metrics);
+        copy.add(new MetricInfo(s, metric, labels));
+        metrics = copy;
+        return this;
+    }
+
+    boolean removeMetric(String codahaleName) {
+        for (int i = 0; i < metrics.size(); i++) {
+            if (metrics.get(i).sourceName.equals(codahaleName)) {
+                List<MetricInfo> copy = new ArrayList<MetricInfo>(metrics);
+                copy.remove(i);
+                metrics = copy;
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/PrometheusReporter.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/PrometheusReporter.java
@@ -1,0 +1,567 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics3.reporter.config.prometheus;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.activation.MimeType;
+import javax.activation.MimeTypeParseException;
+import javax.net.ssl.SSLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.addthis.metrics.reporter.config.AbstractPrometheusReporterConfig;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricRegistryListener;
+import com.codahale.metrics.Timer;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContentCompressor;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.CharsetUtil;
+import io.prometheus.client.Prometheus;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaders.Names.DATE;
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+public class PrometheusReporter
+{
+    private static final Logger log = LoggerFactory.getLogger(PrometheusReporter.class);
+
+    private final PrometheusReporterConfig config;
+    private MetricRegistry registry;
+    private MetricsListener metricsListener;
+
+    private volatile Map<String, MetricsContainer> metrics = new HashMap<String, MetricsContainer>();
+    private Channel nettyChannel;
+
+    public PrometheusReporter(MetricRegistry registry, PrometheusReporterConfig config)
+    {
+        this.registry = registry;
+        this.config = config;
+
+        for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+            mapping.regex = Pattern.compile(mapping.pattern);
+            log.info("Initializing Prometheus metrics mapping with regex '{}'", mapping.regex);
+        }
+
+        for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+            exclusion.regex = Pattern.compile(exclusion.pattern);
+            log.info("Initializing Prometheus metrics exclusion with regex '{}'", exclusion.regex);
+        }
+
+        log.info("Setting up Prometheus metrics exporter on {} port {} and SSL {}", config.host, config.port, config.ssl ? "enabled" : "disabled");
+
+        metricsListener = new MetricsListener();
+        registry.addListener(metricsListener);
+
+        try {
+            setupNetty();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to setup metrics exporter", e);
+        }
+    }
+
+    private synchronized void addMetricsContainer(MetricsContainer container) {
+        Map<String, MetricsContainer> copy = new HashMap<String, MetricsContainer>(metrics);
+        copy.put(container.name, container);
+        metrics = copy;
+    }
+
+    private synchronized void removeMetricsContainer(String name) {
+        Map<String, MetricsContainer> copy = new HashMap<String, MetricsContainer>(metrics);
+        copy.remove(name);
+        metrics = copy;
+    }
+
+    /**
+     * Programmatic helper method to debug metric mappings.
+     * Pass in a <em>codahale</em> metric name and get the <em>mapped</em>
+     * name back.
+     *
+     * @param codahaleName codahale metric name
+     * @return mapped name or {@code null}, if not mapped
+     */
+    public String debugGetMappedName(String codahaleName) {
+        for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+            if (exclusion.regex.matcher(codahaleName).matches()) {
+                return null;
+            }
+        }
+        for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+            Matcher matcher = mapping.regex.matcher(codahaleName);
+            if (matcher.matches()) {
+                return matcher.replaceAll(mapping.name);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Programmatic helper method to debug metric mappings.
+     * Pass in a <em>codahale</em> metric name and get the <em>mapped</em>
+     * labels back.
+     *
+     * @param codahaleName codahale metric name
+     * @return mapped labels or {@code null}, if not mapped
+     */
+    public Map<String, String> debugGetMappedLabels(String codahaleName) {
+        for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+            if (exclusion.regex.matcher(codahaleName).matches()) {
+                return null;
+            }
+        }
+        for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+            Matcher matcher = mapping.regex.matcher(codahaleName);
+            if (matcher.matches()) {
+                Map<String, String> labels = new HashMap<String, String>();
+                for (AbstractPrometheusReporterConfig.Label label : mapping.labels) {
+                    labels.put(
+                    matcher.replaceAll(label.label),
+                    matcher.replaceAll(label.value));
+                }
+                return labels;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Stop the metrics exporter.
+     */
+    public void stop() {
+        log.info("Stopping Prometheus metrics exporter");
+
+        registry.removeListener(metricsListener);
+
+        if (nettyChannel != null)
+        {
+            nettyChannel.close();
+            nettyChannel.closeFuture().syncUninterruptibly();
+        }
+    }
+
+    private void sendMetrics(ResponseFormat responseFormat, OutputStream output) throws IOException
+    {
+        BufferedOutputStream buffered = new BufferedOutputStream(output);
+        Object out = responseFormat.createOutput(buffered);
+        for (MetricsContainer metricsContainer : metrics.values()) {
+            try {
+                if (log.isTraceEnabled()) {
+                    MetricsContainer container = metricsContainer;
+                    log.trace(".. sending container {} of type {}", container.name, container.type);
+                    for (MetricInfo metric : container.getMetrics()) {
+                        log.trace(".... metric {} ({})", metric.sourceName, metric.metric.getClass().getName());
+                        for (String[] label : metric.labels) {
+                            log.trace("....   label: {}={} ", label[0], label[1]);
+                        }
+                    }
+                }
+                responseFormat.writeMetric(metricsContainer, out);
+            } catch (Exception ex) {
+                log.error("Not including metrics for '" + metricsContainer.name + "' due to failure constructing these metrics", ex);
+            }
+        }
+        log.trace(".. metrics sent");
+        responseFormat.finish(out);
+        buffered.flush();
+    }
+
+    private void setupNetty() throws CertificateException, SSLException
+    {
+        final SslContext sslCtx;
+        if (config.ssl) {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            log.info("Setting up SSL context for certificate subject DN {} valid until {}", ssc.cert().getSubjectDN(), ssc.cert().getNotAfter());
+            sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
+        } else {
+            sslCtx = null;
+        }
+
+        final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        final EventLoopGroup workerGroup = new NioEventLoopGroup();
+
+        this.nettyChannel = new ServerBootstrap()
+                            .option(ChannelOption.SO_BACKLOG, 1024)
+                            .group(bossGroup, workerGroup)
+                            .channel(NioServerSocketChannel.class)
+                            .childHandler(new ServerInitializer(sslCtx))
+                            .bind(config.host, config.port).syncUninterruptibly().channel();
+
+        nettyChannel.closeFuture().addListener(new ChannelFutureListener()
+        {
+            public void operationComplete(ChannelFuture future) throws Exception
+            {
+                log.info("Shutting down listener");
+                bossGroup.shutdownGracefully();
+                workerGroup.shutdownGracefully();
+            }
+        });
+    }
+
+    private class ServerInitializer extends ChannelInitializer<SocketChannel>
+    {
+
+        private final SslContext sslCtx;
+
+        private ServerInitializer(SslContext sslCtx) {
+            this.sslCtx = sslCtx;
+        }
+
+        @Override
+        public void initChannel(SocketChannel ch) {
+            ChannelPipeline p = ch.pipeline();
+            if (sslCtx != null) {
+                p.addLast(sslCtx.newHandler(ch.alloc()));
+            }
+            p.addLast("decoder", new HttpRequestDecoder());
+            p.addLast("encoder", new HttpResponseEncoder());
+            p.addLast("compressor", new HttpContentCompressor());
+            p.addLast("handler", new ServerHandler());
+        }
+    }
+
+    private class ServerHandler extends ChannelInboundHandlerAdapter
+    {
+        @Override
+        public void channelRead(final ChannelHandlerContext ctx, Object msg) {
+            if (msg instanceof HttpRequest) {
+                HttpRequest req = (HttpRequest) msg;
+
+                log.debug("HTTP request {}", req);
+
+                if (!req.getDecoderResult().isSuccess()) {
+                    sendError(ctx, BAD_REQUEST);
+                    return;
+                }
+
+                if (req.getMethod() != GET) {
+                    sendError(ctx, METHOD_NOT_ALLOWED);
+                    return;
+                }
+
+                if (HttpHeaders.is100ContinueExpected(req)) {
+                    ctx.write(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE));
+                }
+
+                ResponseFormat responseFormat = responseFormat(req);
+
+                boolean keepAlive = HttpHeaders.isKeepAlive(req);
+                HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
+                HttpHeaders.setHeader(response, CONTENT_TYPE, responseFormat.contentType());
+                HttpHeaders.setDateHeader(response, DATE, new Date());
+                HttpHeaders.setTransferEncodingChunked(response);
+
+                if (keepAlive) {
+                    response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                }
+
+                ctx.write(response);
+
+                log.debug("Sending response as {}", responseFormat.contentType());
+
+                try {
+                    sendMetrics(responseFormat, new OutputStream() {
+                        @Override
+                        public void write(byte[] b, int off, int len) throws IOException {
+                            ctx.write(new DefaultHttpContent(Unpooled.wrappedBuffer(b, off, len)));
+                        }
+
+                        @Override
+                        public void write(int b) throws IOException {
+                            throw new UnsupportedOperationException();
+                        }
+                    });
+                } catch (Throwable e) {
+                    log.info("Error during response processing", e);
+                    sendError(ctx, INTERNAL_SERVER_ERROR);
+                }
+
+                ChannelFuture lastContentFuture = ctx.write(LastHttpContent.EMPTY_LAST_CONTENT);
+                if (!keepAlive) {
+                    lastContentFuture.addListener(ChannelFutureListener.CLOSE);
+                }
+
+                ctx.flush();
+            }
+        }
+
+        private void sendError(ChannelHandlerContext ctx, HttpResponseStatus status) {
+            FullHttpResponse response = new DefaultFullHttpResponse(
+                                                                   HTTP_1_1, status, Unpooled.copiedBuffer("Failure: " + status + "\r\n", CharsetUtil.UTF_8));
+            response.headers().set(CONTENT_TYPE, "text/plain; charset=UTF-8");
+
+            // Close the connection as soon as the error message is sent.
+            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+        }
+
+        private ResponseFormat responseFormat(HttpRequest req) {
+            ResponseFormat responseFormat = ResponseFormat.TEXT;
+            String accept = HttpHeaders.getHeader(req, "Accept");
+            if (accept != null) {
+                double qText = 0.0d;
+                double qProtobuf = 0.0d;
+                for (StringTokenizer st = new StringTokenizer(accept, ","); st.hasMoreTokens(); ) {
+                    try {
+                        MimeType mimeType = new MimeType(st.nextToken());
+                        String s2 = mimeType.getPrimaryType();
+                        if (s2.equals("text"))
+                        {
+                            String s = mimeType.getSubType();
+                            if (s.equals("*") || s.equals("plain"))
+                            {
+                                qText = qEval(qText, mimeType);
+                            }
+                        }
+                        else if (s2.equals("application"))
+                        {
+                            String s1 = mimeType.getSubType();
+                            if (s1.equals("vnd.google.protobuf") || s1.equals("octet-stream"))
+                            {
+                                if ("delimited".equals(mimeType.getParameter("encoding")) &&
+                                    "io.prometheus.client.MetricFamily".equals(mimeType.getParameter("proto")))
+                                    qProtobuf = qEval(qProtobuf, mimeType);
+                            }
+                        }
+                    } catch (MimeTypeParseException e) {
+                        // just ignore this
+                    }
+                }
+                if (qProtobuf > qText)
+                    responseFormat = ResponseFormat.PROTOBUF;
+            }
+            log.trace("Chosen response format {} for HTTP Accept:{}", responseFormat.contentType(), accept);
+            return responseFormat;
+        }
+
+        private double qEval(double currentQ, MimeType mimeType) {
+            String sq = mimeType.getParameter("q");
+            double q = sq != null ? Double.parseDouble(sq.trim()) : 0.01d;
+            return Math.max(q, currentQ);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            cause.printStackTrace();
+            ctx.close();
+        }
+    }
+
+    private class MetricsListener implements MetricRegistryListener
+    {
+        private final Pattern VALIDATION_PATTERN = Pattern.compile("[a-zA-Z_:][a-zA-Z0-9_:]*");
+
+        private synchronized void unregisterMetric(String codahaleName) {
+            for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+                if (exclusion.regex.matcher(codahaleName).matches()) {
+                    return;
+                }
+            }
+
+            for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+                Matcher matcher = mapping.regex.matcher(codahaleName);
+                if (matcher.matches()) {
+                    String name = matcher.replaceAll(mapping.name);
+
+                    MetricsContainer container = metrics.get(name);
+                    if (container.removeMetric(codahaleName)) {
+                        return;
+                    }
+                }
+            }
+
+            String name = convert(codahaleName);
+            removeMetricsContainer(name);
+        }
+
+        private synchronized void registerMetric(String codahaleName, Metric metric) {
+            for (AbstractPrometheusReporterConfig.Exclusion exclusion : config.exclusions) {
+                if (exclusion.regex.matcher(codahaleName).matches()) {
+                    return;
+                }
+            }
+
+            Prometheus.MetricType type;
+            if (metric instanceof Gauge) {
+                type = Prometheus.MetricType.GAUGE;
+            } else if ((metric instanceof Counter) || (metric instanceof Meter)) {
+                type = Prometheus.MetricType.COUNTER;
+            } else if ((metric instanceof Histogram) || (metric instanceof Timer)) {
+                type = Prometheus.MetricType.SUMMARY;
+            } else {
+                throw new UnsupportedOperationException("Unknown metric of type " + metric.getClass().getName());
+            }
+
+            for (AbstractPrometheusReporterConfig.Mapping mapping : config.mappings) {
+                Matcher matcher = mapping.regex.matcher(codahaleName);
+                if (matcher.matches()) {
+                    log.debug("{} matches {}", codahaleName, mapping.pattern);
+                    String name = matcher.replaceAll(mapping.name);
+
+                    List<String[]> labels = new ArrayList<String[]>();
+                    for (AbstractPrometheusReporterConfig.Label label : mapping.labels) {
+                        labels.add(new String[]{
+                        matcher.replaceAll(label.label),
+                        matcher.replaceAll(label.value)
+                        });
+                    }
+
+                    if (!VALIDATION_PATTERN.matcher(name).matches())
+                        log.warn("Invalid Prometheus metric name '{}' (from '{}')", name, codahaleName);
+                    else {
+                        MetricsContainer container = metrics.get(name);
+                        if (container == null) {
+                            addMetricsContainer(container = new MetricsContainer(name, "from codahale", type));
+                        } else {
+                            if (container.type != type) {
+                                log.error("Existing metrics with name '{}' are of type '{}' but metric to be registered '{}' is of type '{}'",
+                                             container.name, container.type, codahaleName, type);
+                                return;
+                            }
+                        }
+                        container.addMetric(codahaleName, metric, labels.toArray(new String[labels.size()][]));
+                    }
+
+                    return;
+                }
+            }
+
+            log.info("No matching metric mapping for '{}'", codahaleName);
+            String name = convert(codahaleName);
+            MetricsContainer container = new MetricsContainer(name, "from codahale", type);
+            container.addMetric(codahaleName, metric);
+            addMetricsContainer(container);
+        }
+
+        private String convert(String s) {
+            StringBuilder sb = new StringBuilder(s.length());
+            for (int i = 0; i < s.length(); i++) {
+                char c = s.charAt(i);
+                switch (c) {
+                    case '.':
+                        c = '_';
+                        break;
+                    case '-':
+                        c = '_';
+                        break;
+                }
+                sb.append(c);
+            }
+            s = sb.toString();
+            if (!VALIDATION_PATTERN.matcher(s).matches())
+                log.warn("Metric name {} does not validate", s);
+            return s;
+        }
+
+        @Override
+        public void onGaugeAdded(String s, Gauge<?> gauge) {
+            registerMetric(s, gauge);
+        }
+
+        @Override
+        public void onGaugeRemoved(String s) {
+            unregisterMetric(s);
+        }
+
+        @Override
+        public void onCounterAdded(String s, Counter counter) {
+            registerMetric(s, counter);
+        }
+
+        @Override
+        public void onCounterRemoved(String s) {
+            unregisterMetric(s);
+        }
+
+        @Override
+        public void onHistogramAdded(String s, Histogram histogram) {
+            registerMetric(s, histogram);
+        }
+
+        @Override
+        public void onHistogramRemoved(String s) {
+            unregisterMetric(s);
+        }
+
+        @Override
+        public void onMeterAdded(String s, Meter meter) {
+            registerMetric(s, meter);
+        }
+
+        @Override
+        public void onMeterRemoved(String s) {
+            unregisterMetric(s);
+        }
+
+        @Override
+        public void onTimerAdded(String s, Timer timer) {
+            registerMetric(s, timer);
+        }
+
+        @Override
+        public void onTimerRemoved(String s) {
+            unregisterMetric(s);
+        }
+    }
+}

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/PrometheusReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/PrometheusReporterConfig.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics3.reporter.config.prometheus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.addthis.metrics.reporter.config.AbstractPrometheusReporterConfig;
+import com.addthis.metrics3.reporter.config.MetricsReporterConfigThree;
+import com.codahale.metrics.MetricRegistry;
+
+public class PrometheusReporterConfig extends AbstractPrometheusReporterConfig implements MetricsReporterConfigThree
+{
+    private static final Logger log = LoggerFactory.getLogger(PrometheusReporterConfig.class);
+
+    private PrometheusReporter reporter;
+
+    @Override
+    public boolean enable(MetricRegistry registry)
+    {
+        boolean success = setup("com.addthis.metrics3.reporter.config.prometheus.PrometheusReporter") &&
+                          setup("com.google.protobuf.ProtocolMessageEnum") &&
+                          setup("io.prometheus.client.Collector");
+        if (!success)
+        {
+            return false;
+        }
+
+        try
+        {
+            enableMetrics3(registry);
+        }
+        catch (Exception e)
+        {
+            log.error("Faliure while enabling PrometheusReporter", e);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void enableMetrics3(MetricRegistry registry)
+    {
+        reporter = new PrometheusReporter(registry, this);
+    }
+
+    private boolean setup(String className)
+    {
+        if (!isClassAvailable(className))
+        {
+            log.error("Tried to enable PrometheusReporter, but class {} was not found", className);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void report()
+    {
+         // noop - prometheus polls metrics
+    }
+
+    /**
+     * Stop the metrics exporter.
+     */
+    public void stop() {
+        if (reporter != null)
+        {
+            reporter.stop();
+        }
+    }
+
+    public PrometheusReporter getReporter()
+    {
+        return reporter;
+    }
+}

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/ResponseFormat.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/ResponseFormat.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.metrics3.reporter.config.prometheus;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Counting;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metered;
+import com.codahale.metrics.Sampling;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import com.google.protobuf.CodedOutputStream;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Prometheus;
+
+public interface ResponseFormat<O> {
+
+    double FACTOR_TIMER = 1.0d / TimeUnit.SECONDS.toNanos(1L);
+
+    String contentType();
+
+    void writeMetric(MetricsContainer metrics, O writer) throws IOException;
+
+    O createOutput(OutputStream output);
+
+    void finish(O output) throws IOException;
+
+    ResponseFormat TEXT = new TextFormat();
+    ResponseFormat PROTOBUF = new ProtobufFormat();
+
+    final class TextFormat implements ResponseFormat<Writer> {
+        private static final Logger LOGGER = LoggerFactory.getLogger(TextFormat.class);
+        private static final String CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
+
+        @Override
+        public String contentType() {
+            return CONTENT_TYPE_004;
+        }
+
+        @Override
+        public Writer createOutput(OutputStream output) {
+            return new OutputStreamWriter(output);
+        }
+
+        @Override
+        public void finish(Writer output) throws IOException {
+            output.flush();
+        }
+
+        @Override
+        public void writeMetric(MetricsContainer metrics, Writer writer) throws IOException {
+            writer.write("# HELP " + metrics.name + " from dropwizard/codahale\n");
+            writer.write("# TYPE " + metrics.name + " " + metrics.typeName + "\n");
+
+            for (MetricInfo metric : metrics.getMetrics()) {
+                switch (metrics.type) {
+                    case GAUGE:
+                    case COUNTER:
+                        double value = 0;
+                        if (metric.metric instanceof Gauge) {
+                            Object obj = ((Gauge) metric.metric).getValue();
+                            if (obj instanceof Number) {
+                                value = ((Number) obj).doubleValue();
+                            } else if (obj instanceof Boolean) {
+                                value = ((Boolean) obj) ? 1 : 0;
+                            } else {
+                                continue;
+                            }
+                        } else if (metric.metric instanceof Metered) {
+                            value = ((Metered) metric.metric).getCount();
+                        } else if (metric.metric instanceof Counting) {
+                            value = ((Counting) metric.metric).getCount();
+                        }
+                        writer.write(metrics.name);
+                        writer.write(textLabels(metric.labels, true));
+                        writer.write(" ");
+                        writer.write(Collector.doubleToGoString(value) + "\n");
+                        break;
+                    case SUMMARY:
+                        boolean isTimer = metric.metric instanceof Timer;
+                        double factor = isTimer ? FACTOR_TIMER : 1.0d;
+
+                        Snapshot snapshot = ((Sampling) metric.metric).getSnapshot();
+
+                        long sum = 0;
+                        for (long i : snapshot.getValues()) {
+                            sum += i;
+                        }
+
+                        String labels = textLabels(metric.labels, false);
+                        try {
+                            sampleValue(writer, metrics.name, labels, "0.5", snapshot.getMedian() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.75", snapshot.get75thPercentile() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.95", snapshot.get95thPercentile() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.98", snapshot.get98thPercentile() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.99", snapshot.get99thPercentile() * factor);
+                            sampleValue(writer, metrics.name, labels, "0.999", snapshot.get999thPercentile() * factor);
+                            sampleValue(writer, metrics.name + "_count", labels, null, ((Counting) metric.metric).getCount());
+                            sampleValue(writer, metrics.name + "_sum", labels, null, sum * factor);
+                        }
+                        catch (Exception e) {
+                            LOGGER.warn("Failed to build metric values for {} ({}) due to {}", metrics.name, metric.sourceName, e.toString());
+                        }
+                        break;
+                }
+            }
+        }
+
+        private String textLabels(String[][] labels, boolean withBrackets) {
+            if (labels.length == 0)
+                return "";
+            StringBuilder sb = new StringBuilder();
+            if (withBrackets)
+                sb.append('{');
+            for (String[] label : labels) {
+                sb.append(label[0]).append('=').append(escapeLabelValue(label[1])).append(',');
+            }
+            if (withBrackets)
+                sb.append('}');
+            return sb.toString();
+        }
+
+        static String escapeLabelValue(String s) {
+            return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+        }
+
+        private void sampleValue(Writer writer, String name, String labels, String quant, double v) throws IOException {
+            writer.write(name);
+            if (quant != null || labels != null)
+                writer.write('{');
+            if (labels != null) {
+                writer.write(labels);
+            }
+            if (quant != null) {
+                writer.write("quantile=\"");
+                writer.write(quant);
+                writer.write("\"");
+            }
+            if (quant != null || labels != null)
+                writer.write('}');
+            writer.write(' ');
+            writer.write(Collector.doubleToGoString(v));
+            writer.write('\n');
+        }
+    }
+
+    final class ProtobufFormat implements ResponseFormat<CodedOutputStream> {
+        private static final Logger LOGGER = LoggerFactory.getLogger(ProtobufFormat.class);
+        private static final String CONTENT_TYPE_004 = "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited";
+
+        @Override
+        public String contentType() {
+            return CONTENT_TYPE_004;
+        }
+
+        @Override
+        public void finish(CodedOutputStream output) throws IOException {
+            output.flush();
+        }
+
+        @Override
+        public CodedOutputStream createOutput(OutputStream output) {
+            return CodedOutputStream.newInstance(output);
+        }
+
+        @Override
+        public void writeMetric(MetricsContainer metrics, CodedOutputStream writer) throws IOException {
+            Prometheus.MetricFamily.Builder builder = Prometheus.MetricFamily.newBuilder().
+                    setHelp("from dropwizard/codahale " + metrics.name).
+                    setName(metrics.name).
+                    setType(metrics.type);
+
+            for (MetricInfo metric : metrics.getMetrics()) {
+                switch (metrics.type) {
+                    case GAUGE:
+                        Object obj = ((Gauge) metric.metric).getValue();
+                        double value;
+                        if (obj instanceof Number) {
+                            value = ((Number) obj).doubleValue();
+                        } else if (obj instanceof Boolean) {
+                            value = ((Boolean) obj) ? 1 : 0;
+                        } else {
+                            return;
+                        }
+                        Prometheus.Metric.Builder metricBuilder = builder.addMetricBuilder();
+                        addLabels(metricBuilder, metric);
+                        metricBuilder.setGauge(Prometheus.Gauge.newBuilder().setValue(value));
+                        break;
+                    case COUNTER:
+                        long v = ((Counting) metric.metric).getCount();
+                        metricBuilder = builder.addMetricBuilder();
+                        addLabels(metricBuilder, metric);
+                        metricBuilder.setCounter(Prometheus.Counter.newBuilder().setValue(v));
+                        break;
+                    case SUMMARY:
+                        boolean isTimer = metric.metric instanceof Timer;
+                        double factor = isTimer ? FACTOR_TIMER : 1.0d;
+                        fromSnapshotAndCount(builder, metrics, metric,
+                                ((Sampling) metric.metric).getSnapshot(),
+                                ((Counting) metric.metric).getCount(), factor);
+                        break;
+                }
+// TODO somehow possible to add mean, one-minute, five-minute, fifteen-minute rates along WITH the histogram/meter ?
+//                if (metric.metric instanceof Metered) {
+//                    Metered metered = (Metered) metric.metric;
+//                    metered.getMeanRate();
+//                    metered.getOneMinuteRate();
+//                    metered.getFiveMinuteRate();
+//                    metered.getFifteenMinuteRate();
+//                }
+            }
+
+            if (builder.getMetricCount() > 0) {
+                writer.writeMessageNoTag(builder.build());
+            }
+        }
+
+        private void addLabels(Prometheus.Metric.Builder metricBuilder, MetricInfo metric) {
+            for (String[] label : metric.labels) {
+                metricBuilder.addLabelBuilder()
+                        .setName(label[0])
+                        .setValue(label[1]);
+            }
+        }
+
+        private void fromSnapshotAndCount(Prometheus.MetricFamily.Builder builder, MetricsContainer metrics, MetricInfo metric, Snapshot snapshot, long count, double factor) {
+            long sum = 0;
+            for (long i : snapshot.getValues()) {
+                sum += i;
+            }
+
+            try {
+                Prometheus.Summary.Builder summaryBuilder = Prometheus.Summary.newBuilder();
+                summaryBuilder.addQuantileBuilder().setQuantile(.5d).setValue(snapshot.getMedian() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.75d).setValue(snapshot.get75thPercentile() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.95d).setValue(snapshot.get95thPercentile() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.98d).setValue(snapshot.get98thPercentile() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.99d).setValue(snapshot.get99thPercentile() * factor);
+                summaryBuilder.addQuantileBuilder().setQuantile(.999d).setValue(snapshot.get999thPercentile() * factor);
+                summaryBuilder.setSampleCount(count);
+                summaryBuilder.setSampleSum(sum * factor);
+                Prometheus.Metric.Builder metricBuilder = builder.addMetricBuilder();
+                addLabels(metricBuilder, metric);
+                metricBuilder.setSummary(summaryBuilder);
+            }
+            catch (Exception e) {
+                LOGGER.warn("Failed to build metric values for {} ({}) due to {}", metrics.name, metric.sourceName, e.toString());
+            }
+        }
+    }
+}

--- a/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/PrometheusConfigTest.java
+++ b/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/PrometheusConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.metrics3.reporter.config;
+
+import java.net.URL;
+
+import org.junit.Test;
+
+import com.addthis.metrics3.reporter.config.prometheus.PrometheusReporterConfig;
+import com.codahale.metrics.MetricRegistry;
+
+public class PrometheusConfigTest
+{
+    @Test
+    public void parseCassandraConfig() throws Exception
+    {
+        MetricRegistry registry = new MetricRegistry();
+
+        URL url = PrometheusConfigTest.class.getResource("/prometheus/prometheus-cassandra.yaml");
+        String file = url.getFile();
+        ReporterConfig config = ReporterConfig.loadFromFile(file);
+        try
+        {
+            for (PrometheusReporterConfig prometheusReporterConfig : config.getPrometheus())
+            {
+                // bind to a random port
+                prometheusReporterConfig.setPort(0);
+            }
+
+            config.enableAll(registry);
+        }
+        finally
+        {
+            for (PrometheusReporterConfig prometheusReporterConfig : config.getPrometheus())
+            {
+                prometheusReporterConfig.stop();
+            }
+        }
+    }
+}

--- a/reporter-config3/src/test/resources/prometheus/prometheus-cassandra.yaml
+++ b/reporter-config3/src/test/resources/prometheus/prometheus-cassandra.yaml
@@ -1,0 +1,198 @@
+prometheus:
+  -
+    host: 'localhost'
+    port: 8088
+    ssl: false
+
+    exclusions:
+      # EstimatedPartitionCount is a very expensive operation which deserializes compaction stats
+      # from all sstables on invocation.
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.EstimatedPartitionCount\..+'
+      # following is for Cassandra < 3.0, since types of metrics vary (GAUGE + COUNTER)
+      - pattern: 'org\.apache\.cassandra\.metrics\.ThreadPools\.TotalBlockedTasks\..+'
+      # following is for Cassandra < 3.0, since types of metrics vary (GAUGE + COUNTER)
+      - pattern: 'org\.apache\.cassandra\.metrics\.ThreadPools\.CurrentlyBlockedTasks\..+'
+
+    # Codahale metrics name mappigns follow.
+    # These mappings group equal metrics of different targets under one name but
+    # specify labels to distinguish them.
+    #
+    # For example, the following mapping exports one name 'BloomFilterDiskSpaceUsed'
+    # containing the values for all tables using different labels.
+    mappings:
+      # example: org.apache.cassandra.metrics.keyspace.CasProposeLatency.workloads
+      - pattern: 'org\.apache\.cassandra\.metrics\.keyspace\.([^.]+)\.([^.]+)'
+        name: 'Keyspace_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$2'
+
+      #
+      # Cassandra >= 3.0
+      #
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.all
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.all$'
+        name: 'TableAll_$1'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system.paxos
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.(([^.]+)\.([^.]+))'
+        name: 'Table_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$3'
+          - label: 'table'
+            value: '$2'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.([^.]+)'
+        name: 'TableKeyspace_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$2'
+
+      #
+      # Cassandra < 3.0
+      #
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.all
+      - pattern: 'org\.apache\.cassandra\.metrics\.ColumnFamily\.([^.]+)\.all$'
+        name: 'TableAll_$1'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system.paxos
+      - pattern: 'org\.apache\.cassandra\.metrics\.ColumnFamily\.([^.]+)\.(([^.]+)\.([^.]+))'
+        name: 'Table_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$3'
+          - label: 'table'
+            value: '$2'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system
+      - pattern: 'org\.apache\.cassandra\.metrics\.ColumnFamily\.([^.]+)\.([^.]+)'
+        name: 'TableKeyspace_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$2'
+
+      # example: org.apache.cassandra.metrics.Connection.TotalTimeouts
+      - pattern: 'org\.apache\.cassandra\.metrics\.Connection\.TotalTimeouts'
+        name: 'ConnectionTotalTimeouts'
+      # example: org.apache.cassandra.metrics.Connection.Timeouts.10.240.0.7
+      - pattern: 'org\.apache\.cassandra\.metrics\.Connection\.Timeouts\.(.+)'
+        name: 'ConnectionTimeouts'
+        labels:
+          - label: 'endpoint'
+            value: '$1'
+      # example: org.apache.cassandra.metrics.Connection.LargeMessagePendingTasks.10.240.0.7
+      - pattern: 'org\.apache\.cassandra\.metrics\.Connection\.([^.]+)\.(.+)'
+        name: 'Connection$1'
+        labels:
+          - label: 'endpoint'
+            value: '$2'
+
+      # example: org.apache.cassandra.metrics.ThreadPools.ActiveTasks.internal.PendingRangeCalculator
+      - pattern: 'org\.apache\.cassandra\.metrics\.ThreadPools\.([^.]+)\.([^.]+)\.([^.]+)'
+        name: 'ThreadPools_$1'
+        labels:
+          - label: 'pool'
+            value: '$3'
+          - label: 'type'
+            value: '$2'
+
+      # example: org.apache.cassandra.metrics.Cache.HitRate.CounterCache
+      - pattern: 'org\.apache\.cassandra\.metrics\.Cache\.([^.]+)\.([^.]+)'
+        name: 'Cache_$1'
+        labels:
+          - label: 'cache'
+            value: '$2'
+
+      # example: org.apache.cassandra.metrics.DroppedMessage.InternalDroppedLatency.PAGED_RANGE
+      - pattern: 'org\.apache\.cassandra\.metrics\.DroppedMessage\.([^.]+)\.(.+)'
+        name: 'DroppedMessage_$1'
+        labels:
+          - label: 'message'
+            value: '$2'
+
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.Compaction\.(.+)'
+        name: 'Compaction_$1'
+
+      # example: org.apache.cassandra.metrics.CommitLog.WaitingOnSegmentAllocation
+      - pattern: 'org\.apache\.cassandra\.metrics\.CommitLog\.(.+)'
+        name: 'CommitLog_$1'
+
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.BufferPool\.(.+)'
+        name: 'BufferPool_$1'
+
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.Storage\.(.+)'
+        name: 'Storage_$1'
+
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.CQL\.(.+)'
+        name: 'CQL_$1'
+
+      # example: org.apache.cassandra.metrics.ClientRequest.ViewPendingMutations.ViewWrite
+      - pattern: 'org\.apache\.cassandra\.metrics\.ClientRequest\.([^.]+)\.([^.]+)'
+        name: 'ClientRequest_$1'
+        labels:
+          - label: 'sensor'
+            value: '$2'
+
+      # example: org.apache.cassandra.metrics.Client.RequestsInFlight
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.RequestsInFlight'
+        name: 'ClientRequestsInFlight'
+
+      # example: org.apache.cassandra.metrics.Client.RequestCount
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.RequestCount'
+        name: 'ClientRequestCount'
+
+      # example: org.apache.cassandra.metrics.Client.Message.QUERY
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.Message\.(.+)'
+        name: 'ClientMessage'
+        labels:
+          - label: 'message'
+            value: '$1'
+
+      # example: org.apache.cassandra.metrics.Client.Error.READ_TIMEOUT
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.Error\.(.+)'
+        name: 'ClientError'
+        labels:
+          - label: 'error'
+            value: '$1'
+
+      # example: org.apache.cassandra.metrics.Client.connectedNativeClients
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.(.+)'
+        name: 'Client_$1'
+
+      # example: org.apache.cassandra.metrics.Index.IndexInfoCount.RowIndexEntry
+      - pattern: 'org\.apache\.cassandra\.metrics\.Index\.([^.]+)\.([^.]+)'
+        name: 'Index_$1'
+        labels:
+          - label: 'type'
+            value: '$2'
+
+      # example: org.apache.cassandra.metrics.ReadRepair.RepairedBlocking
+      - pattern: 'org\.apache\.cassandra\.metrics\.ReadRepair\.(.+)'
+        name: 'ReadRepair_$1'
+
+      # example: org.apache.cassandra.metrics.DirectMemory.Allocated
+      - pattern: 'org\.apache\.cassandra\.metrics\.DirectMemory\.(.+)'
+        name: 'DirectMemory_$1'
+
+    # example org.apache.cassandra.metrics.HintedHandOffManager.Hints_created-10.240.0.10
+      - pattern: 'org\.apache\.cassandra\.metrics\.HintedHandOffManager\.([^-]+)-(.+)'
+        name: '$1'
+        labels:
+          - label: 'endpoint'
+            value: '$2'
+    # example org.apache.cassandra.metrics.Messaging.CrossNodeLatency
+      - pattern: 'org\.apache\.cassandra\.metrics\.Messaging\.CrossNodeLatency'
+        name: 'CrossNodeLatency'
+
+    #
+    # Cassandra < 3.0
+    #
+      - pattern: 'org\.apache\.cassandra\.metrics\.ClientRequestMetrics\.(.+)'
+        name: 'ClientRequestMetrics_$1'
+    #
+    # Cassandra < 3.0
+    #
+      - pattern: 'org\.apache\.cassandra\.metrics\.FileCache\.(.+)'
+        name: 'FileCache_$1'

--- a/reporter-config3/src/test/resources/prometheus/prometheus.yaml
+++ b/reporter-config3/src/test/resources/prometheus/prometheus.yaml
@@ -1,0 +1,11 @@
+prometheus:
+  -
+    host: 'localhost'
+    port: 8088
+    ssl: false
+    mappings:
+      # default mapping, expose the metrics using the metrics name used in codahale
+      - pattern: '(.+)'
+        name: '$1'
+    #exclusions:
+      #- pattern: 'regex-pattern-to-exclude-a-metrics'

--- a/samples/prometheus-cassandra.yaml
+++ b/samples/prometheus-cassandra.yaml
@@ -1,0 +1,198 @@
+prometheus:
+  -
+    host: 'localhost'
+    port: 8088
+    ssl: false
+
+    exclusions:
+      # EstimatedPartitionCount is a very expensive operation which deserializes compaction stats
+      # from all sstables on invocation.
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.EstimatedPartitionCount\..+'
+      # following is for Cassandra < 3.0, since types of metrics vary (GAUGE + COUNTER)
+      - pattern: 'org\.apache\.cassandra\.metrics\.ThreadPools\.TotalBlockedTasks\..+'
+      # following is for Cassandra < 3.0, since types of metrics vary (GAUGE + COUNTER)
+      - pattern: 'org\.apache\.cassandra\.metrics\.ThreadPools\.CurrentlyBlockedTasks\..+'
+
+    # Codahale metrics name mappigns follow.
+    # These mappings group equal metrics of different targets under one name but
+    # specify labels to distinguish them.
+    #
+    # For example, the following mapping exports one name 'BloomFilterDiskSpaceUsed'
+    # containing the values for all tables using different labels.
+    mappings:
+      # example: org.apache.cassandra.metrics.keyspace.CasProposeLatency.workloads
+      - pattern: 'org\.apache\.cassandra\.metrics\.keyspace\.([^.]+)\.([^.]+)'
+        name: 'Keyspace_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$2'
+
+      #
+      # Cassandra >= 3.0
+      #
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.all
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.all$'
+        name: 'TableAll_$1'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system.paxos
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.(([^.]+)\.([^.]+))'
+        name: 'Table_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$3'
+          - label: 'table'
+            value: '$2'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system
+      - pattern: 'org\.apache\.cassandra\.metrics\.Table\.([^.]+)\.([^.]+)'
+        name: 'TableKeyspace_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$2'
+
+      #
+      # Cassandra < 3.0
+      #
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.all
+      - pattern: 'org\.apache\.cassandra\.metrics\.ColumnFamily\.([^.]+)\.all$'
+        name: 'TableAll_$1'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system.paxos
+      - pattern: 'org\.apache\.cassandra\.metrics\.ColumnFamily\.([^.]+)\.(([^.]+)\.([^.]+))'
+        name: 'Table_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$3'
+          - label: 'table'
+            value: '$2'
+      # example: org.apache.cassandra.metrics.Table.BloomFilterDiskSpaceUsed.system
+      - pattern: 'org\.apache\.cassandra\.metrics\.ColumnFamily\.([^.]+)\.([^.]+)'
+        name: 'TableKeyspace_$1'
+        labels:
+          - label: 'keyspace'
+            value: '$2'
+
+      # example: org.apache.cassandra.metrics.Connection.TotalTimeouts
+      - pattern: 'org\.apache\.cassandra\.metrics\.Connection\.TotalTimeouts'
+        name: 'ConnectionTotalTimeouts'
+      # example: org.apache.cassandra.metrics.Connection.Timeouts.10.240.0.7
+      - pattern: 'org\.apache\.cassandra\.metrics\.Connection\.Timeouts\.(.+)'
+        name: 'ConnectionTimeouts'
+        labels:
+          - label: 'endpoint'
+            value: '$1'
+      # example: org.apache.cassandra.metrics.Connection.LargeMessagePendingTasks.10.240.0.7
+      - pattern: 'org\.apache\.cassandra\.metrics\.Connection\.([^.]+)\.(.+)'
+        name: 'Connection$1'
+        labels:
+          - label: 'endpoint'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.ThreadPools.ActiveTasks.internal.PendingRangeCalculator
+      - pattern: 'org\.apache\.cassandra\.metrics\.ThreadPools\.([^.]+)\.([^.]+)\.([^.]+)'
+        name: 'ThreadPools_$1'
+        labels:
+          - label: 'pool'
+            value: '$3'
+          - label: 'type'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.Cache.HitRate.CounterCache
+      - pattern: 'org\.apache\.cassandra\.metrics\.Cache\.([^.]+)\.([^.]+)'
+        name: 'Cache_$1'
+        labels:
+          - label: 'cache'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.DroppedMessage.InternalDroppedLatency.PAGED_RANGE
+      - pattern: 'org\.apache\.cassandra\.metrics\.DroppedMessage\.([^.]+)\.(.+)'
+        name: 'DroppedMessage_$1'
+        labels:
+          - label: 'message'
+            value: '$2'
+    
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.Compaction\.(.+)'
+        name: 'Compaction_$1'
+    
+      # example: org.apache.cassandra.metrics.CommitLog.WaitingOnSegmentAllocation
+      - pattern: 'org\.apache\.cassandra\.metrics\.CommitLog\.(.+)'
+        name: 'CommitLog_$1'
+    
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.BufferPool\.(.+)'
+        name: 'BufferPool_$1'
+    
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.Storage\.(.+)'
+        name: 'Storage_$1'
+    
+    # example:
+      - pattern: 'org\.apache\.cassandra\.metrics\.CQL\.(.+)'
+        name: 'CQL_$1'
+    
+      # example: org.apache.cassandra.metrics.ClientRequest.ViewPendingMutations.ViewWrite
+      - pattern: 'org\.apache\.cassandra\.metrics\.ClientRequest\.([^.]+)\.([^.]+)'
+        name: 'ClientRequest_$1'
+        labels:
+          - label: 'sensor'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.Client.RequestsInFlight
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.RequestsInFlight'
+        name: 'ClientRequestsInFlight'
+    
+      # example: org.apache.cassandra.metrics.Client.RequestCount
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.RequestCount'
+        name: 'ClientRequestCount'
+    
+      # example: org.apache.cassandra.metrics.Client.Message.QUERY
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.Message\.(.+)'
+        name: 'ClientMessage'
+        labels:
+          - label: 'message'
+            value: '$1'
+    
+      # example: org.apache.cassandra.metrics.Client.Error.READ_TIMEOUT
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.Error\.(.+)'
+        name: 'ClientError'
+        labels:
+          - label: 'error'
+            value: '$1'
+    
+      # example: org.apache.cassandra.metrics.Client.connectedNativeClients
+      - pattern: 'org\.apache\.cassandra\.metrics\.Client\.(.+)'
+        name: 'Client_$1'
+    
+      # example: org.apache.cassandra.metrics.Index.IndexInfoCount.RowIndexEntry
+      - pattern: 'org\.apache\.cassandra\.metrics\.Index\.([^.]+)\.([^.]+)'
+        name: 'Index_$1'
+        labels:
+          - label: 'type'
+            value: '$2'
+    
+      # example: org.apache.cassandra.metrics.ReadRepair.RepairedBlocking
+      - pattern: 'org\.apache\.cassandra\.metrics\.ReadRepair\.(.+)'
+        name: 'ReadRepair_$1'
+    
+      # example: org.apache.cassandra.metrics.DirectMemory.Allocated
+      - pattern: 'org\.apache\.cassandra\.metrics\.DirectMemory\.(.+)'
+        name: 'DirectMemory_$1'
+    
+    # example org.apache.cassandra.metrics.HintedHandOffManager.Hints_created-10.240.0.10
+      - pattern: 'org\.apache\.cassandra\.metrics\.HintedHandOffManager\.([^-]+)-(.+)'
+        name: '$1'
+        labels:
+          - label: 'endpoint'
+            value: '$2'
+    # example org.apache.cassandra.metrics.Messaging.CrossNodeLatency
+      - pattern: 'org\.apache\.cassandra\.metrics\.Messaging\.CrossNodeLatency'
+        name: 'CrossNodeLatency'
+
+    #
+    # Cassandra < 3.0
+    #
+      - pattern: 'org\.apache\.cassandra\.metrics\.ClientRequestMetrics\.(.+)'
+        name: 'ClientRequestMetrics_$1'
+    #
+    # Cassandra < 3.0
+    #
+      - pattern: 'org\.apache\.cassandra\.metrics\.FileCache\.(.+)'
+        name: 'FileCache_$1'


### PR DESCRIPTION
This proposed patch integrates metrics exporting for prometheus.
It eliminates the need for the prometheus graphite-exporter (or any other exporter) between the monitored application and prometheus.
In order to do that, it opens its own HTTP listener, which can optionally encrypted using a self-signed certificate. (More SSL support could be added on top of that.)

The patch integrates both into yammer and codahale modules.

An example reporter/exporter config is included for Apache Cassandra and has been tested with versions 2.1.x and 3.x.

A big section of the configuration (as in the example config) is dedicated to map yammer/codahale metric names to prometheus names and labels.