### PR TITLE
Add support for mesurementMappings in the InfluxDB reporter config

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -190,6 +190,8 @@ InfluxDB connection requires a few more configuration properties:
         tags:
          host: '${host.name}'
          env: 'prod'
+        measurementMappings:
+         cassandra_Table_ReadLatency: org.apache.cassandra.metrics.Table.ReadLatency.*
         prefix: ''
         hosts:
           - host: 'localhost'

--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractInfluxDBReporterConfig.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractInfluxDBReporterConfig.java
@@ -17,6 +17,7 @@ package com.addthis.metrics.reporter.config;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -49,6 +50,9 @@ public class AbstractInfluxDBReporterConfig extends AbstractHostPortReporterConf
     private Map<String, String> tags;
 
     private Map<String, String> resolvedTags;
+
+    @NotNull
+    private Map<String, String> measurementMappings = Collections.emptyMap();
 
     @Override
     public List<HostPort> getFullHostList()
@@ -119,4 +123,8 @@ public class AbstractInfluxDBReporterConfig extends AbstractHostPortReporterConf
     {
         this.readTimeout = readTimeout;
     }
+
+    public Map<String, String> getMeasurementMappings() { return measurementMappings; }
+
+    public void setMeasurementMappings(Map<String, String> measurementMappings) { this.measurementMappings = measurementMappings; }
 }

--- a/reporter-config-base/src/test/resources/sample/influxdb.yaml
+++ b/reporter-config-base/src/test/resources/sample/influxdb.yaml
@@ -11,6 +11,8 @@ influxdb:
       host: 'node1'
       env: 'prod'
       sth: 'else'
+    measurementMappings:
+      cassandra_Table_ReadLatency: org.apache.cassandra.metrics.Table.ReadLatency.*
     prefix: ''
     hosts:
       - host: 'localhost'

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/InfluxDBReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/InfluxDBReporterConfig.java
@@ -41,6 +41,7 @@ public class InfluxDBReporterConfig extends AbstractInfluxDBReporterConfig imple
 
         reporter = InfluxDbReporter.forRegistry(registry).convertRatesTo(getRealRateunit())
             .convertDurationsTo(getRealDurationunit()).withTags(getResolvedTags())
+            .measurementMappings(getMeasurementMappings())
             .filter(MetricFilterTransformer.generateFilter(getPredicate())).build(influxDbSender);
 
         reporter.start(getPeriod(), getRealTimeunit());


### PR DESCRIPTION
I want to use this for publishing Cassandra metrics and need to use the measurementMappings to group metrics, to avoid getting too fine grained ones.

Let me know if something is missing.
/BR Jimmy