### PR TITLE
Add JVM metrics to metrics3's ReporterConfig

### DIFF
--- a/reporter-config3/pom.xml
+++ b/reporter-config3/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>metrics-core</artifactId>
             <version>${dep.metrics3.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jvm</artifactId>
+            <version>${dep.metrics3.version}</version>
+        </dependency>
         <!-- reporters -->
         <!-- console, csv, jmx included in core -->
         <dependency>

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/ReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/ReporterConfig.java
@@ -18,12 +18,15 @@ import javax.validation.Valid;
 
 import java.io.IOException;
 
+import java.lang.management.ManagementFactory;
 import java.util.List;
 
 import com.addthis.metrics.reporter.config.AbstractReporterConfig;
 
+import com.codahale.metrics.JvmAttributeGaugeSet;
 import com.codahale.metrics.MetricRegistry;
 
+import com.codahale.metrics.jvm.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -287,6 +290,7 @@ public class ReporterConfig extends AbstractReporterConfig {
         if (!enabled) {
             log.warn("No reporters were succesfully enabled");
         }
+        registerJvmMetrics(registry);
         return enabled;
     }
 
@@ -296,6 +300,16 @@ public class ReporterConfig extends AbstractReporterConfig {
                 reporter.report();
             }
         }
+    }
+
+    private void registerJvmMetrics(MetricRegistry registry) {
+        registry.register("jvm.attribute", new JvmAttributeGaugeSet());
+        registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+        registry.register("jvm.classloader", new ClassLoadingGaugeSet());
+        registry.register("jvm.filedescriptor", new FileDescriptorRatioGauge());
+        registry.register("jvm.gc", new GarbageCollectorMetricSet());
+        registry.register("jvm.memory", new MemoryUsageGaugeSet());
+        registry.register("jvm.threads", new ThreadStatesGaugeSet());
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
This adds the JVM-level metrics that [dropwizard supplies](http://metrics.dropwizard.io/3.1.0/manual/jvm/).