### PR TITLE
Add per-measurement level filtering of metrics in metrics3

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -124,7 +124,7 @@ name (`org.example.foo.MyClass`) enable `useQualifiedName`.
 that are reported by a meter then use can use the measurement options
 on the predicate configuration. This feature is only available if you
 include as a dependency a fork of the metrics project that supports
-this feature, such as http://github.com/mspiegel/metrics.  If the per
+this feature, such as http://github.com/thelastpickle/metrics.  If the per
 measurement filtering is available then it is only applied once a
 metric has passed the top level filter.
 

--- a/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/MetricPredicateTransformer.java
+++ b/reporter-config2/src/main/java/com/addthis/metrics/reporter/config/MetricPredicateTransformer.java
@@ -82,7 +82,7 @@ public class MetricPredicateTransformer
 
         /**
          * This will only be invoked if using a fork of the metrics library with support
-         * for filtering on a per-measurement basis - http://github.com/mspiegel/metrics.
+         * for filtering on a per-measurement basis - http://github.com/thelastpickle/metrics.
          * Otherwise this method is not invoked. The @Override annotation is omitted so
          * that compilation is successful using either the metrics library or the fork of the
          * metrics library.


### PR DESCRIPTION
This configuration exists but is only used in metrics2.
This commit implements it in the metrics3 code as well.
It also updates links to point to a metrics fork that provides the functionality advertised.

ref: https://github.com/addthis/metrics-reporter-config/pull/2