### PR TITLE
Make JVM metrics optional and off by default

### DIFF
--- a/reporter-config-base/src/test/resources/sample/console-jvm-metrics-enabled.yaml
+++ b/reporter-config-base/src/test/resources/sample/console-jvm-metrics-enabled.yaml
@@ -1,0 +1,5 @@
+jvmMetricsEnabled: true
+console:
+  -
+    period: 2
+    timeunit: 'SECONDS'

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/ReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/ReporterConfig.java
@@ -57,6 +57,8 @@ public class ReporterConfig extends AbstractReporterConfig {
     @Valid
     private List<PrometheusReporterConfig> prometheus;
 
+    private boolean jvmMetricsEnabled = false;
+
     public List<ConsoleReporterConfig> getConsole() {
         return console;
     }
@@ -127,6 +129,14 @@ public class ReporterConfig extends AbstractReporterConfig {
 
     public List<PrometheusReporterConfig> getPrometheus() {
         return this.prometheus;
+    }
+
+    public boolean isJvmMetricsEnabled() {
+        return jvmMetricsEnabled;
+    }
+
+    public void setJvmMetricsEnabled(boolean jvmMetricsEnabled) {
+        this.jvmMetricsEnabled = jvmMetricsEnabled;
     }
 
     public boolean enableConsole(MetricRegistry registry) {
@@ -290,7 +300,9 @@ public class ReporterConfig extends AbstractReporterConfig {
         if (!enabled) {
             log.warn("No reporters were succesfully enabled");
         }
-        registerJvmMetrics(registry);
+        if (jvmMetricsEnabled) {
+            registerJvmMetrics(registry);
+        }
         return enabled;
     }
 

--- a/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/sample/ValidateTest.java
+++ b/reporter-config3/src/test/java/com/addthis/metrics3/reporter/config/sample/ValidateTest.java
@@ -34,6 +34,7 @@ public class ValidateTest
     public void validateSamples() throws IOException
     {
         ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/console.yaml");
+        ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/console-jvm-metrics-enabled.yaml");
         ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/csv.yaml");
         ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/ganglia.yaml");
         ReporterConfig.loadFromFileAndValidate("src/test/resources/sample/ganglia-gmond.yaml");


### PR DESCRIPTION
This is a quick fix for https://github.com/addthis/metrics-reporter-config/issues/42 though a full suite of configurable options might be better in the future.