### PR TITLE
Added support for spoof name in gmetric output for ganglia

### DIFF
--- a/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractGangliaReporterConfig.java
+++ b/reporter-config-base/src/main/java/com/addthis/metrics/reporter/config/AbstractGangliaReporterConfig.java
@@ -15,15 +15,14 @@
 package com.addthis.metrics.reporter.config;
 
 
-import java.util.List;
-
 import javax.validation.constraints.NotNull;
+
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AbstractGangliaReporterConfig extends AbstractHostPortReporterConfig
-{
+public class AbstractGangliaReporterConfig extends AbstractHostPortReporterConfig {
     private static final Logger log = LoggerFactory.getLogger(AbstractGangliaReporterConfig.class);
 
     @NotNull
@@ -31,24 +30,21 @@ public class AbstractGangliaReporterConfig extends AbstractHostPortReporterConfi
     @NotNull
     protected boolean compressPackageNames = false;
     protected String gmondConf;
+    protected String spoofName;
 
-    public boolean getCompressPackageNames()
-    {
+    public boolean getCompressPackageNames() {
         return compressPackageNames;
     }
 
-    public void setCompressPackageNames(boolean compressPackageNames)
-    {
+    public void setCompressPackageNames(boolean compressPackageNames) {
         this.compressPackageNames = compressPackageNames;
     }
 
-    public String getGmondConf()
-    {
+    public String getGmondConf() {
         return gmondConf;
     }
 
-    public void setGmondConf(String gmondConf)
-    {
+    public void setGmondConf(String gmondConf) {
         this.gmondConf = gmondConf;
     }
 
@@ -60,35 +56,35 @@ public class AbstractGangliaReporterConfig extends AbstractHostPortReporterConfi
         this.groupPrefix = groupPrefix;
     }
 
-    @Override
-    public List<HostPort> getFullHostList()
-    {
-         if (gmondConf != null)
-         {
-             GmondConfigParser gcp = new GmondConfigParser();
-             List<HostPort> confHosts = gcp.getGmondSendChannels(gmondConf);
-             if (confHosts == null || confHosts.isEmpty())
-             {
-                 log.warn("No send channels found after reading {}", gmondConf);
-             }
-             return confHosts;
-         }
-         else
-         {
-             return getHostListAndStringList();
-         }
+    public String getSpoofName() {
+        return spoofName;
     }
 
-    protected boolean setup(String className)
-    {
-        if (!isClassAvailable(className))
-        {
+    public void setSpoofName(String spoofName) {
+        this.spoofName = spoofName;
+    }
+
+    @Override
+    public List<HostPort> getFullHostList() {
+        if (gmondConf != null) {
+            GmondConfigParser gcp = new GmondConfigParser();
+            List<HostPort> confHosts = gcp.getGmondSendChannels(gmondConf);
+            if (confHosts == null || confHosts.isEmpty()) {
+                log.warn("No send channels found after reading {}", gmondConf);
+            }
+            return confHosts;
+        } else {
+            return getHostListAndStringList();
+        }
+    }
+
+    protected boolean setup(String className) {
+        if (!isClassAvailable(className)) {
             log.error("Tried to enable GangliaReporter, but class {} was not found", className);
             return false;
         }
         List<HostPort> hosts = getFullHostList();
-        if (hosts == null || hosts.isEmpty())
-        {
+        if (hosts == null || hosts.isEmpty()) {
             log.error("No hosts specified, cannot enable GangliaReporter");
             return false;
         }

--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/GangliaReporterConfig.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/GangliaReporterConfig.java
@@ -20,15 +20,16 @@ import java.util.List;
 
 import com.addthis.metrics.reporter.config.AbstractGangliaReporterConfig;
 import com.addthis.metrics.reporter.config.HostPort;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ganglia.GangliaReporter;
 
-import info.ganglia.gmetric4j.gmetric.GMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class GangliaReporterConfig extends AbstractGangliaReporterConfig implements MetricsReporterConfigThree
-{
+import info.ganglia.gmetric4j.gmetric.GMetric;
+
+public class GangliaReporterConfig extends AbstractGangliaReporterConfig implements MetricsReporterConfigThree {
     private static final Logger log = LoggerFactory.getLogger(GangliaReporterConfig.class);
 
     private GangliaReporter reporter;
@@ -39,34 +40,28 @@ public class GangliaReporterConfig extends AbstractGangliaReporterConfig impleme
          * "ttl" parameter is ignored for GMetric.UDPAddressingMode.UNICAST
          */
         reporter = GangliaReporter.forRegistry(registry)
-        .convertRatesTo(getRealRateunit())
-        .convertDurationsTo(getRealDurationunit())
-        .prefixedWith(groupPrefix)
-        .filter(MetricFilterTransformer.generateFilter(getPredicate()))
-        .build(new GMetric(hostPort.getHost(), hostPort.getPort(),
-                GMetric.UDPAddressingMode.UNICAST, 1));
+                                  .convertRatesTo(getRealRateunit())
+                                  .convertDurationsTo(getRealDurationunit())
+                                  .prefixedWith(groupPrefix)
+                                  .filter(MetricFilterTransformer.generateFilter(getPredicate()))
+                                  .build(new GMetric(hostPort.getHost(), hostPort.getPort(),
+                                                     GMetric.UDPAddressingMode.UNICAST, 1, true, null, getSpoofName()));
 
         reporter.start(getPeriod(), getRealTimeunit());
     }
 
     @Override
-    public boolean enable(MetricRegistry registry)
-    {
+    public boolean enable(MetricRegistry registry) {
         boolean success = setup("com.codahale.metrics.ganglia.GangliaReporter");
-        if (!success)
-        {
+        if (!success) {
             return false;
         }
         List<HostPort> hosts = getFullHostList();
-        for (HostPort hostPort : hosts)
-        {
+        for (HostPort hostPort : hosts) {
             log.info("Enabling GangliaReporter to {}:{}", new Object[]{hostPort.getHost(), hostPort.getPort()});
-            try
-            {
+            try {
                 enableMetrics3(hostPort, registry);
-            }
-            catch (Exception e)
-            {
+            } catch (Exception e) {
                 log.error("Faliure while enabling GangliaReporter", e);
                 return false;
             }


### PR DESCRIPTION
This PR should provide backwards compatibility. As you can see [here](https://github.com/ganglia/gmetric4j/blob/master/src/main/java/info/ganglia/gmetric4j/gmetric/GMetric.java#L39) if no spoof name is provided it will be the same values is it is now (true, null , null). However, if you specify the spoof name that last null will be specified.

Example) config value: `spoofName: 192.158.1.5:testing`  

https://github.com/ganglia/monitor-core/wiki/Gmetric-Spoofing