### PR TITLE
Make job optional in prometheus exporter

### DIFF
--- a/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/MetricRegistryDecorator.java
+++ b/reporter-config3/src/main/java/com/addthis/metrics3/reporter/config/prometheus/MetricRegistryDecorator.java
@@ -30,6 +30,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,8 +49,10 @@ public class MetricRegistryDecorator extends Collector {
     public MetricRegistryDecorator(MetricRegistry registry, String job, Map<String, String> labels) {
         this.registry = registry;
 
-        labelNames.add("job");
-        labelValues.add(job);
+        if (StringUtils.isNotBlank(job)) {
+            labelNames.add("job");
+            labelValues.add(job);
+        }
 
         for (Map.Entry<String, String> entry : labels.entrySet()) {
             labelNames.add(entry.getKey());


### PR DESCRIPTION
Job label is useful on push, but not servlet pull in our environment because of prometheus/k8s scrape configs. This allows us to not set job w/o the servlet throwing an NPE