### PR TITLE
remove bad space from graphite example config

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -71,7 +71,7 @@ An example config file might look like this:
         timeunit: 'SECONDS'
         hosts:
          - host: 'graphite-server.domain.local'
-            port: 2003
+           port: 2003
 
 
 And then to wire up your app call


### PR DESCRIPTION
Fixes yaml in example Graphite config. May save someone somewhere ~15 minutes of bother.